### PR TITLE
feat: add sandbox indicator module

### DIFF
--- a/barista.conf
+++ b/barista.conf
@@ -91,9 +91,12 @@ MODULE_NODE="false"
 MODULE_WEATHER="false"
 MODULE_TIMEZONE="false"
 
+# Sandbox indicator (shows lock icon when in macOS app sandbox)
+MODULE_SANDBOX="true"
+
 # Module display order (comma-separated, no spaces)
 # Add modules here to display them. Order determines display position.
-MODULE_ORDER="directory,context,git,project,model,cost,rate-limits,time,battery"
+MODULE_ORDER="sandbox,directory,context,git,project,model,cost,rate-limits,time,battery"
 
 # Example with system modules:
 # MODULE_ORDER="directory,git,cpu,memory,disk,model,cost,rate-limits,time,battery"

--- a/barista.sh
+++ b/barista.sh
@@ -51,6 +51,7 @@ MODULE_NODE="false"
 MODULE_PROCESSES="false"
 MODULE_WEATHER="false"
 MODULE_TIMEZONE="false"
+MODULE_SANDBOX="true"
 MODULE_VERSION="true"
 MODULE_UPDATE="true"
 
@@ -120,7 +121,7 @@ load_config_safe() {
             PROJECT_*=*|MODEL_*=*|COST_*=*|RATE_*=*|TIME_*=*|\
             BATTERY_*=*|CPU_*=*|MEMORY_*=*|DISK_*=*|NETWORK_*=*|\
             UPTIME_*=*|LOAD_*=*|TEMP_*=*|BRIGHTNESS_*=*|PROC_*=*|\
-            DOCKER_*=*|NODE_*=*|WEATHER_*=*|TIMEZONE_*=*|\
+            DOCKER_*=*|NODE_*=*|WEATHER_*=*|TIMEZONE_*=*|SANDBOX_*=*|\
             CACHE_MAX_AGE=*|DEBUG_MODE=*|LAYOUT_MODE=*|\
             TERMINAL_WIDTH=*|RIGHT_SIDE_RESERVE=*|VERSION_*=*|UPDATE_*=*)
                 # Extract key and value
@@ -227,6 +228,7 @@ get_module_function() {
         processes)    echo "module_processes" ;;
         weather)      echo "module_weather" ;;
         timezone)     echo "module_timezone" ;;
+        sandbox)      echo "module_sandbox" ;;
         version)      echo "module_version" ;;
         update)       echo "module_update" ;;
         *)            echo "" ;;
@@ -304,6 +306,7 @@ is_module_enabled() {
         processes)    enabled="${MODULE_PROCESSES:-false}" ;;
         weather)      enabled="${MODULE_WEATHER:-false}" ;;
         timezone)     enabled="${MODULE_TIMEZONE:-false}" ;;
+        sandbox)      enabled="${MODULE_SANDBOX:-false}" ;;
         version)      enabled="${MODULE_VERSION:-false}" ;;
         update)       enabled="${MODULE_UPDATE:-false}" ;;
         *)            enabled="false" ;;
@@ -449,7 +452,7 @@ main() {
     fi
 
     # Default module order if not specified
-    local DEFAULT_ORDER="version,update,directory,context,git,project,model,cost,rate-limits,time,battery"
+    local DEFAULT_ORDER="sandbox,version,update,directory,context,git,project,model,cost,rate-limits,time,battery"
 
     # Use custom order if specified, otherwise use default
     local module_order="${MODULE_ORDER:-$DEFAULT_ORDER}"

--- a/install.sh
+++ b/install.sh
@@ -312,6 +312,7 @@ do_update() {
 # =============================================================================
 # Format: "module_name:default_enabled:category"
 declare -a CORE_MODULES=(
+    "sandbox:true:core"
     "version:true:core"
     "update:true:core"
     "directory:true:core"
@@ -401,6 +402,7 @@ get_module_description() {
 
     case "$module" in
         # Core modules
+        sandbox)      icon="$(emoji '🔒' '[S]')"; text="Lock icon when in macOS app sandbox" ;;
         version)      icon="$(emoji '☕' '[V]')"; text="Barista version (shown briefly on startup)" ;;
         update)       icon="$(emoji '⬆️ ' '[U]')"; text="Update checker (daily GitHub check)" ;;
         directory)    icon="$(emoji '📁' '[D]')"; text="Current directory name" ;;
@@ -454,6 +456,13 @@ get_module_sample() {
     local bar="${PROGRESS_FILLED}${PROGRESS_FILLED}${PROGRESS_FILLED}${PROGRESS_FILLED}${PROGRESS_EMPTY}${PROGRESS_EMPTY}${PROGRESS_EMPTY}${PROGRESS_EMPTY}"
 
     case "$module" in
+        sandbox)
+            if [ "$USE_EMOJI" = "true" ]; then
+                echo "🔒"
+            else
+                echo "SANDBOX"
+            fi
+            ;;
         directory)
             if [ "$USE_EMOJI" = "true" ]; then
                 echo "📁 myproject"

--- a/modules/sandbox.sh
+++ b/modules/sandbox.sh
@@ -1,0 +1,17 @@
+# ABOUTME: Sandbox indicator module - shows a lock icon when running in an macOS app sandbox
+# ABOUTME: Detects sandbox via the APP_SANDBOX_CONTAINER_ID environment variable
+
+# =============================================================================
+# Sandbox Module - Shows lock icon when in macOS app sandbox
+# =============================================================================
+# Configuration options:
+#   SANDBOX_ICON - Icon to display (default: 🔒)
+# =============================================================================
+
+module_sandbox() {
+    # Only show when running in a sandbox
+    [ -n "${APP_SANDBOX_CONTAINER_ID:-}" ] || return
+
+    local icon=$(get_icon "${SANDBOX_ICON:-🔒}" "SANDBOX")
+    echo "$icon"
+}

--- a/tests/test_sandbox.sh
+++ b/tests/test_sandbox.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# ABOUTME: Tests for the sandbox module - verifies lock icon display based on APP_SANDBOX_CONTAINER_ID
+# ABOUTME: Run with: bash tests/test_sandbox.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected: '$expected'"
+        echo "    actual:   '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_empty() {
+    local desc="$1" actual="$2"
+    if [ -z "$actual" ]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected empty, got: '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Load utils and sandbox module
+. "$SCRIPT_DIR/modules/utils.sh"
+. "$SCRIPT_DIR/modules/sandbox.sh"
+
+echo "=== Sandbox Module Tests ==="
+
+# Test 1: No output when APP_SANDBOX_CONTAINER_ID is not set
+echo "Test: no output when not in sandbox"
+unset APP_SANDBOX_CONTAINER_ID
+USE_ICONS="true"
+result=$(module_sandbox)
+assert_empty "no output when APP_SANDBOX_CONTAINER_ID is unset" "$result"
+
+# Test 2: Shows lock icon when APP_SANDBOX_CONTAINER_ID is set
+echo "Test: shows lock icon when in sandbox"
+APP_SANDBOX_CONTAINER_ID="com.apple.security.sandbox.test"
+USE_ICONS="true"
+SANDBOX_ICON="🔒"
+result=$(module_sandbox)
+assert_eq "shows lock icon when sandboxed" "🔒" "$result"
+
+# Test 3: Respects custom icon
+echo "Test: respects custom SANDBOX_ICON"
+APP_SANDBOX_CONTAINER_ID="something"
+SANDBOX_ICON="🔐"
+USE_ICONS="true"
+result=$(module_sandbox)
+assert_eq "uses custom icon" "🔐" "$result"
+
+# Test 4: Works with icons disabled
+echo "Test: works with icons disabled"
+APP_SANDBOX_CONTAINER_ID="something"
+USE_ICONS="false"
+SANDBOX_ICON="🔒"
+result=$(module_sandbox)
+assert_eq "shows fallback text when icons disabled" "SANDBOX" "$result"
+
+unset APP_SANDBOX_CONTAINER_ID
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Adds a new `sandbox` module that displays a 🔒 lock icon when `APP_SANDBOX_CONTAINER_ID` is set, indicating the session is running inside a macOS app sandbox
- Produces no output when not sandboxed, so it's zero-cost for non-sandbox users
- Enabled by default, placed first in module order for visibility

## Details

- New file: `modules/sandbox.sh` — standalone module following existing patterns
- Customizable via `SANDBOX_ICON` config (default: 🔒), falls back to `SANDBOX` text when icons are disabled
- `SANDBOX_*` added to safe config parser allowlist for per-project overrides
- Includes unit tests in `tests/test_sandbox.sh`

## Test plan

- [x] Unit tests pass (`bash tests/test_sandbox.sh` — 4/4 passing)
- [x] Integration test: lock icon appears when `APP_SANDBOX_CONTAINER_ID` is set
- [x] Integration test: no output when `APP_SANDBOX_CONTAINER_ID` is unset
- [ ] Verify in actual Claude Code sandbox environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)