### PR TITLE
fix: shadow-safe stat on Darwin (gnubin PATH compat)

### DIFF
--- a/modules/network.sh
+++ b/modules/network.sh
@@ -65,7 +65,7 @@ module_network() {
         local wan_ip=""
 
         if [ -f "$wan_cache" ]; then
-            local cache_age=$(($(date +%s) - $(stat -f %m "$wan_cache" 2>/dev/null || echo 0)))
+            local cache_age=$(( $(date +%s) - $(_file_mtime "$wan_cache") ))
             if [ "$cache_age" -lt 300 ]; then
                 wan_ip=$(cat "$wan_cache")
             fi

--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -66,13 +66,10 @@ _check_backoff() {
     local duration="${stored_duration:-$default_duration}"
 
     local backoff_time
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        backoff_time=$(stat -f %m "$backoff_file" 2>/dev/null || echo 0)
-    else
-        backoff_time=$(stat -c %Y "$backoff_file" 2>/dev/null || echo 0)
-    fi
+    backoff_time=$(_file_mtime "$backoff_file")
 
-    local now=$(date +%s)
+    local now
+    now=$(date +%s)
     local backoff_age=$((now - backoff_time))
 
     if [ "$backoff_age" -lt "$duration" ]; then
@@ -256,7 +253,7 @@ module_rate_limits() {
         local max_history_size=51200
         local current_size=0
         if [ -f "$history_file" ]; then
-            current_size=$(stat -f %z "$history_file" 2>/dev/null || echo 0)
+            current_size=$(_file_size "$history_file")
         fi
 
         # Cleanup first if file is too large

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -7,6 +7,35 @@
 # =============================================================================
 
 # =============================================================================
+# PORTABLE FILE STAT HELPERS
+# =============================================================================
+# Call `/usr/bin/stat` with an absolute path on Darwin so GNU coreutils
+# (brew `gnubin` in PATH) cannot shadow BSD stat — GNU's `-f` means
+# `--file-system`, which returns garbage and silently breaks cache age /
+# rate-limit backoff / history-size math.
+# Fall back to GNU `stat -c` on Linux and to `0` on any failure.
+
+_file_mtime() {
+    local f="$1"
+    [ -e "$f" ] || { echo 0; return; }
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        /usr/bin/stat -f %m "$f" 2>/dev/null || echo 0
+    else
+        stat -c %Y "$f" 2>/dev/null || echo 0
+    fi
+}
+
+_file_size() {
+    local f="$1"
+    [ -e "$f" ] || { echo 0; return; }
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        /usr/bin/stat -f %z "$f" 2>/dev/null || echo 0
+    else
+        stat -c %s "$f" 2>/dev/null || echo 0
+    fi
+}
+
+# =============================================================================
 # CACHE SYSTEM
 # =============================================================================
 # Simple file-based caching for expensive operations (weather, network, etc.)
@@ -40,17 +69,14 @@ cache_get() {
 
     # Check age
     local file_time
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        file_time=$(stat -f %m "$cache_file" 2>/dev/null)
-    else
-        file_time=$(stat -c %Y "$cache_file" 2>/dev/null)
-    fi
+    file_time=$(_file_mtime "$cache_file")
 
-    if [ -z "$file_time" ]; then
+    if [ "$file_time" -eq 0 ]; then
         return 1
     fi
 
-    local current_time=$(date +%s)
+    local current_time
+    current_time=$(date +%s)
     local age=$((current_time - file_time))
 
     if [ "$age" -gt "$max_age" ] 2>/dev/null; then

--- a/modules/weather.sh
+++ b/modules/weather.sh
@@ -29,7 +29,7 @@ module_weather() {
 
     # Check cache
     if [ -f "$cache_file" ]; then
-        local cache_age=$(($(date +%s) - $(stat -f %m "$cache_file" 2>/dev/null || echo 0)))
+        local cache_age=$(( $(date +%s) - $(_file_mtime "$cache_file") ))
         if [ "$cache_age" -lt "$cache_ttl" ]; then
             weather_data=$(cat "$cache_file")
         fi


### PR DESCRIPTION
## Summary

Automated scan (2026-04-15) of `Barista`. Syntax clean across all 29
shell files, 4 passing sandbox-indicator tests, functional smoke test
succeeds. The previous scan (2026-04-11) returned a clean bill of
health, but the QA agent uncovered a real portability bug that
previous scans missed: every `stat -f %m|%z` call silently breaks
when a user has `brew install coreutils` with `gnubin` ahead of
`/usr/bin` in `PATH` (a common macOS developer setup). GNU `stat`
interprets `-f` as `--file-system`, returning a multi-line filesystem
dump instead of an mtime, which then cascades into arithmetic and
comparison errors downstream.

## Changes Made

### `modules/utils.sh` — new portable helpers

- **What:** Added `_file_mtime` and `_file_size` helpers near the top of
  utils.sh. Both use `/usr/bin/stat` with an **absolute path** on
  Darwin so GNU coreutils cannot shadow BSD stat via `$PATH`, and fall
  back to `stat -c %Y` / `stat -c %s` on Linux. Both return `0` on
  missing-file or error so callers can branch cleanly on the result.
- **Why:** Relying on `stat -f %m` working "because we're on Darwin" is
  unsafe — a user with `/opt/homebrew/opt/coreutils/libexec/gnubin`
  (or the Intel equivalent) in PATH will hit GNU stat first and the
  flag means something completely different. This is a common
  developer configuration and the bug is silent: rate-limit backoff,
  cache expiry, and the history-file-size cap all quietly stop
  working.
- **How:** Two small functions, fully Bash 3.2-compatible, no external
  dependencies beyond the existing `stat` binary.

### Five call sites converted

| File | Line | Purpose | Helper used |
|---|---|---|---|
| `modules/utils.sh` | cache_get age check | cache expiry | `_file_mtime` |
| `modules/network.sh` | WAN IP cache | 5-min cache | `_file_mtime` |
| `modules/weather.sh` | weather cache | `WEATHER_CACHE_TTL` | `_file_mtime` |
| `modules/rate-limits.sh` | 429 backoff age | retry-after compliance | `_file_mtime` |
| `modules/rate-limits.sh` | history file size cap | 50KB ceiling | `_file_size` |

Three of these (`network.sh`, `weather.sh`, `rate-limits.sh:259`) were
**bare `stat -f` calls with no OS check at all** — so they weren't
just susceptible to PATH shadowing on macOS, they were also broken on
Linux under the existing Linux-fallback pattern used elsewhere in
`rate-limits.sh`. The helper centralizes the check.

## What Was NOT Changed

- **`install.sh` SC2120 (`do_update` references `$@` but is called without
  args)** — Functionally benign: the function uses `exec "$SCRIPT_DIR/install.sh"
  "$@"` to re-launch after a pull, and since no call site passes args, no args
  are lost in practice today. A proper fix either threads the script's real
  `$@` through all three call sites or adds a `# shellcheck disable=SC2120`
  directive. Deferring — not worth mixing cosmetic cleanup into this bug-fix PR.
- **SC2001 style findings in `barista.sh`** (5 `sed` calls for ANSI stripping)
  — style-level, identical patterns, trivial but not bug-fix-adjacent.
- **Adding `tests/run.sh` harness** — The repo currently has a single runnable
  test (`tests/test_sandbox.sh`, 4/4 passing). A proper harness deserves its
  own PR once there is more than one test file.
- **Medium/low findings from the security agent** (`rate-limits.sh` linear
  history search perf, `weather.sh` overly-strict location regex, `disk.sh`
  DISK_PATH validation, `brightness.sh` ioreg parsing) — all already mitigated
  by existing safeguards (50KB cap, safe config parser, empty default).
  Verified, not worth churn.

## Verification

- **Syntax (`bash -n`):** PASS on all 4 touched files; full repo still PASS at
  29/29.
- **Shellcheck delta (4 touched files, default severity):**
  - `modules/utils.sh`: 18 → **17** (-1)
  - `modules/network.sh`: 3 → 3 (unchanged)
  - `modules/weather.sh`: 8 → 8 (unchanged)
  - `modules/rate-limits.sh`: 39 → **38** (-1)
  - Net: **-2**. No new SC codes introduced.
- **Functional smoke test** (JSON piped through `barista.sh` with
  `/usr/bin` forced ahead of PATH to simulate a stock-macOS user):
  **EXIT 0**, clean output, all modules rendered (directory, context,
  git, model, rate-limits, date/time, battery).
- **Sandbox module unit test** (`tests/test_sandbox.sh`): 4/4 passing,
  unchanged.

## Scan notes

- No open issues, no open PRs prior to scan.
- Only 3 commits in 14 days (#14 docs, #15 new sandbox module, #17
  auto-scan fixes). Codebase is actively hardening; this PR adds the
  one remaining portability gap the prior three scans missed.
- Step 5b deep cleanup pass **skipped** — lint is actively improving
  (baseline dossier reported 38 warnings, live count shows the codebase
  has been cleaned up substantially since; the recorded metric is stale
  and would benefit from being re-measured in the dossier on merge).