### PR TITLE
rate-limits: support Windows / Git Bash environments

### DIFF
--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -21,9 +21,23 @@
 #   RATE_BACKOFF_SECONDS    - Fallback backoff after 429 if no retry-after header (default: 300)
 # =============================================================================
 
-# Extract OAuth token from macOS Keychain
+# Extract OAuth token from (in order):
+#   1. ~/.claude/.credentials.json — used on Windows and some Linux setups
+#   2. macOS Keychain via `security` — used on macOS
 # Handles both plain JSON and hex-encoded formats (macOS 15+ / recent Claude Code)
 _get_claude_token() {
+    local creds_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json"
+    if [ -f "$creds_file" ]; then
+        local file_token
+        file_token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+        if [ -n "$file_token" ]; then
+            echo "$file_token"
+            return
+        fi
+    fi
+
+    command -v security >/dev/null 2>&1 || return
+
     local raw
     raw=$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null)
     [ -z "$raw" ] && return
@@ -110,8 +124,23 @@ _get_claude_usage() {
     init_cache
     printf 'header = "Authorization: Bearer %s"\n' "$token" > "$tmp_curlcfg"
     chmod 600 "$tmp_curlcfg" 2>/dev/null
+    # On Git Bash / MSYS, some mingw curl builds (notably 8.8 shipped with
+    # recent Git for Windows) hit libcurl error 43 on this endpoint due to a
+    # schannel TLS-renegotiation bug. Windows' system curl.exe works fine.
+    local curl_bin="curl"
+    case "$(uname -s 2>/dev/null)" in
+        MINGW*|MSYS*|CYGWIN*)
+            local sys_curl=""
+            if command -v cygpath >/dev/null 2>&1 && [ -n "$SYSTEMROOT" ]; then
+                sys_curl="$(cygpath -u "$SYSTEMROOT" 2>/dev/null)/System32/curl.exe"
+            fi
+            [ -x "${sys_curl:-/c/Windows/System32/curl.exe}" ] && \
+                curl_bin="${sys_curl:-/c/Windows/System32/curl.exe}"
+            ;;
+    esac
+
     local http_code
-    http_code=$(curl -s --max-time 5 -o "$tmp_file" -D "$tmp_headers" -w "%{http_code}" \
+    http_code=$("$curl_bin" -s --max-time 5 -o "$tmp_file" -D "$tmp_headers" -w "%{http_code}" \
         --config "$tmp_curlcfg" \
         "https://api.anthropic.com/api/oauth/usage" \
         -H "anthropic-beta: oauth-2025-04-20" \


### PR DESCRIPTION
## Summary

Two small fixes to `modules/rate-limits.sh` so the module works on Windows (Git Bash / MSYS2 / Cygwin). Before this PR, the statusline correctly ran end-to-end on Windows but `rate-limits` always showed `5h:-- 7d:--`.

**1. Token source — read `~/.claude/.credentials.json` before calling macOS Keychain.**
On Windows (and some Linux installs) Claude Code stores the OAuth token in a JSON file at `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json`, using the same `.claudeAiOauth.accessToken` shape the module already expects. We try the file first; if missing or empty, we fall back to the existing `security find-generic-password` call. macOS behavior is unchanged when the file is absent, and `command -v security` is now checked so a missing binary is silent instead of noisy.

**2. curl binary — prefer Windows' system `curl.exe` under MINGW/MSYS/Cygwin.**
The mingw curl shipped with recent Git for Windows (`curl 8.8.0` at time of writing) fails with libcurl error 43 ("a libcurl function was given a bad argument") on `https://api.anthropic.com/api/oauth/usage` — the server requests a TLS renegotiation and schannel trips over it. The Windows system curl (`curl 8.16.0` in `C:\Windows\System32\curl.exe`) handles the same request fine. We detect MSYS via `uname -s` and prefer the system curl when present. Path is resolved via `$SYSTEMROOT` + `cygpath` when available, falling back to `/c/Windows/System32/curl.exe`.

## Why this is low-risk

- macOS and Linux code paths are unchanged when `.credentials.json` is absent and `uname -s` isn't MINGW/MSYS/Cygwin.
- On Linux installs that *do* keep creds in `.credentials.json`, the module now works instead of silently failing the `security` call.
- The curl swap only fires on Windows and only if the system `curl.exe` exists.

## Test plan

- [x] Windows 11 + Git Bash: statusline shows real `5h:X% 7d:Y%` values instead of `--`.
- [x] Confirmed `curl -sS --max-time 5 ... /api/oauth/usage` reproduces libcurl error 43 with `/mingw64/bin/curl` (8.8.0) and succeeds with `/c/Windows/System32/curl.exe` (8.16.0) on the same machine.
- [ ] Not retested on macOS — please sanity-check that the file-first token lookup doesn't break macOS when a stray `.credentials.json` exists; in practice macOS Claude Code uses the Keychain so the file shouldn't be there, but worth noting.