### PR TITLE
Scan 2026-04-21: grep -F for fixed-string timestamp match

### DIFF
--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -318,7 +318,7 @@ module_rate_limits() {
 
         # 5-hour projection
         if [ -f "$history_file" ] && [ "$five_hour_remaining" -gt 0 ]; then
-            local current_window_data=$(grep "$five_hour_reset" "$history_file" 2>/dev/null | tail -10)
+            local current_window_data=$(grep -F "$five_hour_reset" "$history_file" 2>/dev/null | tail -10)
             if [ -n "$current_window_data" ]; then
                 local first_entry=$(echo "$current_window_data" | head -1)
                 local last_entry=$(echo "$current_window_data" | tail -1)
@@ -350,7 +350,7 @@ module_rate_limits() {
 
         # 7-day projection (needs 12h of data)
         if [ -f "$history_file" ] && [ "$seven_day_remaining" -gt 0 ]; then
-            local current_window_data=$(grep "$seven_day_reset" "$history_file" 2>/dev/null | tail -50)
+            local current_window_data=$(grep -F "$seven_day_reset" "$history_file" 2>/dev/null | tail -50)
             if [ -n "$current_window_data" ]; then
                 local first_entry=$(echo "$current_window_data" | head -1)
                 local last_entry=$(echo "$current_window_data" | tail -1)


### PR DESCRIPTION
## Summary

Two commits have landed since the 2026-04-15 scan — PR #18 (Darwin stat shadow-safety) and PR #19 (Windows/Git Bash rate-limits). Both verified sound. Security agent surfaced one LOW defense-in-depth nit; QA agent found the dossier's ShellCheck baseline number is a stale word-count (actual is 50 findings, not ~215). Fixed the LOW nit; no other code changes this pass.

## Changes Made

### `modules/rate-limits.sh` — `grep -F` for fixed-string match (commit `666794d`)
- **What:** Two `grep "$X" "$history_file"` sites (lines 321, 353) now use `grep -F`.
- **Why:** `$five_hour_reset` and `$seven_day_reset` are ISO 8601 timestamps from the API's `.resets_at` field. The code at line 313 already accounts for fractional seconds (`${five_hour_reset%%.*}`), which means the timestamp can contain a literal `.` — in BRE mode that's interpreted as a regex metacharacter. Two CSV rows that differ only in decimal-separator position could in theory false-match each other when the history is scanned. Unlikely in practice (timestamps are self-written, reasonably unique), but `-F` makes the match literal and is strictly better defense-in-depth.
- **Impact:** Zero behavior change for any well-formed history entry. Removes a latent regex-metacharacter footgun.

## What Was NOT Changed

- **No open issues exist** and no open PRs — the backlog is empty. All 13 `audit-2026-04-16` items from prior Better-* app scans don't apply to this repo (different project, different audit).
- **Step 5b deep-cleanup pass:** skipped. The dossier already notes "**Last Deep Cleanup: skipped — only 3 commits in 14 days, lint is improving, surface fixes are the right scope**" — continuing that pattern. This repo gets ~2 commits per fortnight; iterative per-scan fixes are the right cadence.
- **Dossier ShellCheck baseline correction (not a code change, filed in dossier only):** The prior dossier recorded "~215 warnings" from a word-count. The actual finding count (ShellCheck `-f gcc` format: one line per finding) is **50 warnings / 0 errors** — unchanged post-fix. Future scans should compare against 50, not 215.
- **Deferred (unchanged from 2026-04-15 dossier):**
  - `install.sh` SC2120 on `do_update()` — benign, no args lost.
  - `barista.sh` SC2001 ×5 (ANSI-strip via sed) — style-only.
  - No umbrella `tests/run.sh` harness — only one test file exists.
  - Recurring security-agent mediums (rate-limits linear search perf, weather regex, disk path, brightness ioreg) — all already mitigated per dossier.

## Verification

- **Bash syntax (`bash -n`):** 29/29 files PASS
- **ShellCheck (`-S warning -f gcc`):** 50 warnings / 0 errors — unchanged from baseline (no new codes, no regression)
- **Unit tests (`tests/test_sandbox.sh`):** 4/4 passing (unchanged)
- **Functional smoke test under stock PATH:** PASS, exit 0, clean render
- **Dependencies:** `jq` PRESENT, `bc` PRESENT