### PR TITLE
ci: add GitHub Actions workflow for shellcheck + bash -n + smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint-and-test:
+    name: shellcheck + bash -n + smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Show shellcheck + bash version (for baseline reproducibility)
+        run: |
+          shellcheck --version
+          bash --version | head -1
+
+      - name: Bash syntax check
+        run: |
+          bash -n barista.sh
+          bash -n install.sh
+          for f in modules/*.sh tests/*.sh; do
+            [ -f "$f" ] && bash -n "$f"
+          done
+
+      - name: ShellCheck (informational baseline ~234 findings, see issue #21)
+        run: |
+          # Issue #21 tracks the baseline drift between shellcheck versions.
+          # Until a project-wide .shellcheckrc policy is decided, this step
+          # is informational rather than a hard gate. Errors do NOT fail CI.
+          shellcheck barista.sh install.sh modules/*.sh -f gcc | tee shellcheck.log || true
+          echo "Total findings: $(wc -l < shellcheck.log)"
+
+      - name: Smoke tests
+        run: bash tests/test_sandbox.sh


### PR DESCRIPTION
## Summary

Auto-scan 2026-05-05 deep-dispatch pass on Barista. Adds first GitHub Actions CI workflow per fleet pattern (10th this session: better-budget #41, stock-trainer #35, Better-legacy #36, bookmarks #27, save-for-later #38, flyck #61, better-bible-trivia #34, better-pastoral-care #27, tennis-story #76, this one).

## Changes Made

### `ci: add GitHub Actions workflow for shellcheck + bash -n + smoke tests`

- **What:** added `.github/workflows/ci.yml`.
- **Why:** no CI existed; every change relied on local runs.
- **How:** ubuntu-latest runner, runs:
  - `bash -n` syntax check on every `.sh` file
  - `shellcheck` informationally (NOT a hard gate — see "What Was NOT Changed")
  - `tests/test_sandbox.sh` smoke suite
- **Logs `shellcheck --version` + `bash --version`** so baseline drifts are visible going forward — issue #21 was caused by an invisible ShellCheck 0.10.x → 0.11.0 bump that 7× SC2155 noise.

## What Was NOT Changed

- **Issue #21 ShellCheck baseline drift / `.shellcheckrc` policy decision** — author has not engaged in 8 days (across 5 prior scans). Per Lesson 4 protocol, this is now pure-skip territory. The CI workflow keeps shellcheck informational so the existing 234-finding baseline doesn't block all PRs while #21 awaits author resolution. Once the author picks a path (the issue body offers 3), a follow-up PR can either:
  - Adopt option 1 (project-wide `.shellcheckrc` disabling SC2155+SC2034, dropping baseline to ~27) and gate CI on shellcheck strictly,
  - Adopt option 2 (pin shellcheck version), or
  - Adopt option 3 (accept 234 as the baseline, no policy file).
- **234 ShellCheck findings** — within the noise tolerance of the 230-finding baseline at HEAD `6c48e52`; still tracked in the existing `tooling: ShellCheck baseline drift` issue.

## Verification

- `bash -n barista.sh install.sh modules/*.sh tests/*.sh`: PASS
- `bash tests/test_sandbox.sh`: 4/4 PASS
- Workflow YAML lints with `actionlint` (passing — verified locally; standard concurrency + permissions stanza)

## Step 5d Carry-Forwards Re-Verified

- **#21 ShellCheck baseline drift awaiting author** — STILL VALID, **8 days unanswered, 5th unanswered scan, AT pure-skip threshold per Lesson 4**. Future scans treat #21 as resolved-by-defer-indefinitely until author engages.
- **Source byte-identical to PR #20** — verified via `git rev-parse HEAD`. PR #20 is the latest source-touching commit.