### PR TITLE
security: validate config-derived values before bc and URL sinks

### DIFF
--- a/modules/load.sh
+++ b/modules/load.sh
@@ -23,8 +23,8 @@ module_load() {
         num_cpus=$(nproc 2>/dev/null || echo 4)
     fi
 
-    local warn_thresh="${LOAD_WARNING_THRESHOLD:-$num_cpus}"
-    local crit_thresh="${LOAD_CRITICAL_THRESHOLD:-$((num_cpus * 2))}"
+    local warn_thresh=$(safe_int "${LOAD_WARNING_THRESHOLD:-$num_cpus}" "$num_cpus")
+    local crit_thresh=$(safe_int "${LOAD_CRITICAL_THRESHOLD:-$((num_cpus * 2))}" "$((num_cpus * 2))")
 
     # Get load averages
     local load_output=$(uptime 2>/dev/null | awk -F'load average:' '{print $2}')

--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -18,8 +18,8 @@
 module_temperature() {
     local icon=$(get_icon "${TEMP_ICON:-🌡️}" "TEMP:")
     local units="${TEMP_UNITS:-C}"
-    local warn_thresh="${TEMP_WARNING_THRESHOLD:-70}"
-    local crit_thresh="${TEMP_CRITICAL_THRESHOLD:-85}"
+    local warn_thresh=$(safe_int "${TEMP_WARNING_THRESHOLD:-70}" 70)
+    local crit_thresh=$(safe_int "${TEMP_CRITICAL_THRESHOLD:-85}" 85)
     local show_status="${TEMP_SHOW_STATUS:-true}"
 
     local temp=""

--- a/modules/weather.sh
+++ b/modules/weather.sh
@@ -14,6 +14,11 @@
 module_weather() {
     local location="${WEATHER_LOCATION:-}"
     local units="${WEATHER_UNITS:-u}"
+    # Restrict to wttr.in's documented unit flags so a config value can't inject extra URL params
+    case "$units" in
+        m|u|M) ;;
+        *) units="u" ;;
+    esac
     local show_temp="${WEATHER_SHOW_TEMP:-true}"
     local show_cond="${WEATHER_SHOW_COND:-true}"
     local compact="${WEATHER_COMPACT:-false}"


### PR DESCRIPTION
## What

`load_config_safe()` (barista.sh) blocks shell metacharacters in config values (`; | & $( \` > <`) but permits `(` `)` `"` and spaces. Three **allowlisted** config values then flowed into interpreters without type validation:

| Value | Sink | File |
|---|---|---|
| `TEMP_WARNING_THRESHOLD` / `TEMP_CRITICAL_THRESHOLD` | `bc -l` arithmetic | `modules/temperature.sh:21-22` |
| `LOAD_WARNING_THRESHOLD` / `LOAD_CRITICAL_THRESHOLD` | `bc -l` arithmetic | `modules/load.sh:26-27` |
| `WEATHER_UNITS` | interpolated into wttr.in URL after `&` | `modules/weather.sh:16,47` |

### Reachability
A **per-project `.barista.conf` is auto-loaded from the workspace directory** (`barista.sh:429-438`, documented in CLAUDE.md as a config precedence layer). So these values are attacker-*influenceable*: clone a repo with a crafted `.barista.conf`, open it under Claude Code, and the statusline parses it on every render.

### Honest severity
A value like `TEMP_WARNING_THRESHOLD=1 + system("touch /tmp/x")` passes the metachar blocklist and reaches `bc`. **This is not a confirmed RCE** — no mainstream `bc` (POSIX/GNU/busybox/Gavin-Howard 7.x, verified locally: `undefined function: system()`) ships a command-exec builtin. But:
1. routing untrusted config through an interpreter is fragile (some `bc` forks carry extensions), and
2. malformed threshold values already silently break the warn/crit logic.

The `WEATHER_UNITS` gap is a real (low) URL-parameter-injection into the outbound request.

## Fix
Run the four thresholds through the existing `safe_int()` helper (already used in `cost.sh`) — they're integers by contract — and allowlist `WEATHER_UNITS` to wttr.in's documented flags (`m|u|M`). Surgical: 3 files, +9/−4.

## Verification
- `safe_int('1 + system("touch /tmp/PWNED")', 70)` → `70`; `/tmp/PWNED` not created.
- Valid thresholds (70, 90) pass through unchanged; F-conversion still works; both modules render exit 0.
- `WEATHER_UNITS=u&format=%l` → `u`.
- shellcheck clean on all three files; `bash -n` OK; existing test suite 4/4 pass.

## Not in this PR (filing separately)
The full-surface audit also flagged install.sh items — self-update has no checksum/signature before `exec` (the only High), `settings.json` heredoc doesn't escape `BARISTA_DIR`, and the user-level `barista.conf` is sourced without a write-permission check. Those touch the sensitive installer path and the High needs a release-artifact (sha256sums) decision, so they're tracked in a separate issue rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)