### PR TITLE
security(install): build settings.json with jq, not an unescaped heredoc (#28 MED)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1952,15 +1952,14 @@ do_install() {
             print_warning "Could not update settings.json - you may need to configure manually"
         fi
     else
-        cat > "$SETTINGS_FILE" << EOF
-{
-  "statusLine": {
-    "type": "command",
-    "command": "$BARISTA_DIR/barista.sh"
-  }
-}
-EOF
-        print_success "Created settings.json"
+        local tmp_file=$(mktemp)
+        if jq -n --arg cmd "$BARISTA_DIR/barista.sh" '{statusLine: {type: "command", command: $cmd}}' > "$tmp_file" 2>/dev/null; then
+            mv "$tmp_file" "$SETTINGS_FILE"
+            print_success "Created settings.json"
+        else
+            rm -f "$tmp_file"
+            print_warning "Could not create settings.json - you may need to configure manually"
+        fi
     fi
 
     # Final message


### PR DESCRIPTION
## Summary

Least-recently-scanned pass on Barista (bash statusline for Claude Code). Continues the shell-security campaign (#11/#13 config-injection + eval-removal, #12 WAN-privacy, #27 bc/URL sinks). This PR fixes the **MED** item of #28 (settings.json heredoc escaping). A fresh full security pass of the **runtime modules** found **0 new findings** (well-hardened). The **HIGH** self-update-integrity item of #28 stays open — it's a release-process decision (see #28).

## Changes Made — `security(install)` (`8656a65`)
- **`install.sh`** — the *create-new* `settings.json` branch wrote the file via a heredoc interpolating `$BARISTA_DIR` **raw** into the JSON `command` value. An install path containing a `"`, `\`, or newline produced **malformed JSON** (or injected JSON structure). The sibling *update* branch already builds it safely with `jq --arg`; this mirrors that pattern: `jq -n --arg cmd "$BARISTA_DIR/barista.sh" '{statusLine:{type:"command",command:$cmd}}'` → `mktemp` → `mv` on success / `rm` + warn on failure.
- Verified: a hostile `BARISTA_DIR=/tmp/a"b` now emits **valid escaped** JSON (`/tmp/a\"b`); the old heredoc emitted malformed JSON.

## What Was NOT Changed
- **#28 HIGH — installer self-update integrity** (`install.sh:269-300` `exec`s a downloaded zip with no checksum/signature → MITM RCE on `--update` from a non-git checkout). This needs a **release-process decision** (publish `sha256sums` / GPG-sign release artifacts to verify against) — not a code one-liner. Left open; scoped on #28.
- **Runtime modules** (`barista.sh` + `modules/*.sh`) — a fresh full security review found **0 findings**: no `eval`, `jq -r` + validation, `bc` inputs validated (#27 holds), `load_config_safe()` rejects shell metacharacters (`` ` $ ; | & > < ``), hardcoded external HTTPS URLs, WAN-redact opt-in (#12). No change.
- **#26 / #24 / #23** feature-requests (git-TTL-cache, config TUI, Homebrew/npx installer) — author/product judgment.

## Verification
- `bash -n`: **29/29 pass**.
- `shellcheck` (with repo `.shellcheckrc`): **0 errors / 2 warnings** (both pre-existing: `install.sh:225` SC2120, `:1448` SC1090) — no new warnings on the edited lines.
- `tests/test_sandbox.sh`: **4/4 pass**.

refs #28
