### PR TITLE
fix(git): guard cd-back in git module (shellcheck SC2164)

### DIFF
--- a/modules/git.sh
+++ b/modules/git.sh
@@ -37,7 +37,7 @@ module_git() {
 
     # Quick check: are we in a git repo?
     if ! git rev-parse --git-dir >/dev/null 2>&1; then
-        cd "$orig_dir" 2>/dev/null
+        cd "$orig_dir" 2>/dev/null || return
         return
     fi
 
@@ -48,7 +48,7 @@ module_git() {
         # Detached HEAD - show short SHA
         git_branch=$(git rev-parse --short HEAD 2>/dev/null)
         if [ -z "$git_branch" ]; then
-            cd "$orig_dir" 2>/dev/null
+            cd "$orig_dir" 2>/dev/null || return
             return
         fi
         git_branch="($git_branch)"  # Indicate detached state
@@ -145,8 +145,8 @@ module_git() {
         fi
     fi
 
-    # Return to original directory
-    cd "$orig_dir" 2>/dev/null
+    # Return to original directory (best-effort; the result must still print)
+    cd "$orig_dir" 2>/dev/null || true
 
     echo "$result"
 }


### PR DESCRIPTION
## Summary
Small robustness + shellcheck-hygiene fix in the git statusline module. Full-surface security review this scan (incl. a complete read of the 67KB `install.sh`) = **0 new findings**; bash -n 29/29, tests 4/4.

## Change (`modules/git.sh` only)
`git_module` cd's into the target directory, then cd's back to `$orig_dir` in three places — all unguarded (`cd "$orig_dir" 2>/dev/null` with no `||`), flagged by shellcheck **SC2164**:
- `:40` — the not-a-git-repo early bail
- `:51` — the detached-HEAD-with-no-SHA early bail
- `:149` — the final cleanup before `echo "$result"`

If the cd-back fails (e.g. `$orig_dir` was removed/unmounted mid-render), the function would continue in the wrong directory. Fixed:
- `:40` / `:51` → `|| return` (matches the already-guarded cd at `:36`; these paths return immediately anyway)
- `:149` → `|| true` (best-effort cleanup — the computed statusline result must still print even if the cd-back fails)

## What Was NOT Changed
- **#28 part 1 (HIGH, self-update integrity)** — `install.sh:269-300` self-update execs a downloaded zip with no checksum/signature. Re-confirmed present; it's known + scoped, **gated on a release-process decision** (sha256sums / GPG / git-only), not a code one-liner. Unchanged.
- The 2 remaining shellcheck warnings (`install.sh:225` SC2120 — `do_update` references args but none passed, benign; `install.sh:1448` SC1090 — non-constant source, benign) are pre-existing and left as-is.
- #26 / #24 / #23 (feature requests) — not touched.

## Verification
- shellcheck: **0 errors / 2 warnings** (down from 5 — the 3 git.sh SC2164 cleared; remaining 2 are the pre-existing benign install.sh items)
- `bash -n`: **29/29** files
- `tests/test_sandbox.sh`: **4/4**

(Note: a prior scan's baseline recorded these 3 SC2164 as already-cleared / "2 warnings" — but `git.sh` has been byte-stable 8 weeks, so they were always present; this PR is what actually reaches the 0-err/2-warn baseline.)
