### PR TITLE
model(jq): suppress jq stderr in runtime path (last two bare jq calls)

### DIFF
--- a/modules/model.sh
+++ b/modules/model.sh
@@ -16,8 +16,8 @@ module_model() {
     local compact="${MODEL_COMPACT:-false}"
     local style="${MODEL_STYLE:-both}"
 
-    local model_name=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
-    local output_style=$(echo "$input" | jq -r '.output_style.name // "default"')
+    local model_name=$(echo "$input" | jq -r '.model.display_name // "Unknown"' 2>/dev/null)
+    local output_style=$(echo "$input" | jq -r '.output_style.name // "default"' 2>/dev/null)
 
     # Compact model names
     if [ "$compact" = "true" ] || is_compact; then


### PR DESCRIPTION
Closes the tracked-deferred LOW from PR #29's dossier note:

> jq-stderr-leak on malformed stdin (barista.sh) — tiny pre-flagged fix, NOT bundled (kept #29 single-concern) — **fold into a future runtime-path-touching PR.**

(The dossier attributed the leak to `barista.sh`, but `barista.sh:429` already has `2>/dev/null`. The actual outliers were in `modules/model.sh:19,20` — the only bare jq calls left in the runtime path.)

## The change

```diff
-    local model_name=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
-    local output_style=$(echo "$input" | jq -r '.output_style.name // "default"')
+    local model_name=$(echo "$input" | jq -r '.model.display_name // "Unknown"' 2>/dev/null)
+    local output_style=$(echo "$input" | jq -r '.output_style.name // "default"' 2>/dev/null)
```

## Why it matters

On malformed JSON input, jq prints `jq: error (at <stdin>:1): ...` to stderr. Claude Code's statusline subprocess surfaces stderr alongside the rendered line, so a bad input would leak parse errors into the terminal.

This matches the fleet pattern that's already in place — verified every other jq site in the runtime path:
- `barista.sh:429` — has `2>/dev/null` ✓
- `modules/cost.sh:29-34` — multi-line jq, closes with `}' 2>/dev/null` ✓
- `modules/utils.sh:578` — has `2>/dev/null` ✓
- `modules/rate-limits.sh:54` — has `2>/dev/null` ✓

CLAUDE.md (Coding Conventions) also codifies it: *"Error handling — Redirect stderr: `command 2>/dev/null`"*.

## Tested

| Check | Result |
|---|---|
| `bash -n modules/model.sh` | clean |
| `shellcheck --severity=error` (CI gate) | clean |
| `shellcheck` advisory (full) | 2 warnings / 22 info+style — **identical to HEAD baseline** (verified by stash + recount; 0 codes added) |
| `tests/test_sandbox.sh` | 4/4 passing |
| Smoke (well-formed JSON) | stdout `🤖 Claude Sonnet`, stderr 0 bytes |
| Smoke (malformed JSON `this is not json`) | stdout `🤖  ()`, stderr **0 bytes** (was leaking jq parse errors) |

## Not in this PR

- `#28 part-1` (installer self-update integrity HIGH) — still author-gated on a release-process decision (sha256sums / GPG / git-only). The scan-sized verify step is ready to ship once the integrity mechanism is picked.
- `#26` (TTL-cache git output) — author-pending on the staleness tradeoff.
- `#23 / #24` — retired-self-ping features (do-NOT-re-ping).