### PR TITLE
security(config): validate remaining untrusted-config numerics before bc/comparison sinks

### DIFF
--- a/modules/battery.sh
+++ b/modules/battery.sh
@@ -19,8 +19,10 @@ module_battery() {
     local charging_icon="${BATTERY_CHARGING_ICON:-⚡}"
     local low_icon="${BATTERY_LOW_ICON:-🪫}"
     local critical_icon="${BATTERY_CRITICAL_ICON:-🔴}"
-    local low_thresh="${BATTERY_LOW_THRESHOLD:-20}"
-    local crit_thresh="${BATTERY_CRITICAL_THRESHOLD:-10}"
+    # Thresholds may come from an untrusted project .barista.conf and feed the integer
+    # comparisons below — coerce non-numeric values to the defaults (matches cpu.sh).
+    local low_thresh=$(safe_int "${BATTERY_LOW_THRESHOLD:-20}" 20)
+    local crit_thresh=$(safe_int "${BATTERY_CRITICAL_THRESHOLD:-10}" 10)
     local show_pct="${BATTERY_SHOW_PERCENTAGE:-true}"
 
     # Get battery info

--- a/modules/cost.sh
+++ b/modules/cost.sh
@@ -21,6 +21,10 @@ module_cost() {
     local decimals=$(safe_int "${COST_DECIMAL_PLACES:-2}" 2)
     local compact="${COST_COMPACT:-false}"
     local min_display="${COST_MINIMUM_DISPLAY:-0.01}"
+    # COST_MINIMUM_DISPLAY can come from an untrusted project .barista.conf and is
+    # interpolated into the `bc` comparison below — keep it a plain decimal so it can't
+    # carry a bc expression. (Sibling of the bc-sink validation added in #27.)
+    [[ "$min_display" =~ ^[0-9]+(\.[0-9]+)?$ ]] || min_display="0.01"
 
     local result=""
 


### PR DESCRIPTION
## Summary

Closes the two unvalidated **sibling sinks** of PR #27 ("validate config-derived values before bc and URL sinks"). A project-level `.barista.conf` is **untrusted** (loaded from whatever repo you `cd` into, on every statusline render), and two config values still reached numeric sinks without the validation the rest of the codebase applies.

Found by tracing every allowlisted config key from the `load_config_safe()` parser into its downstream sinks.

## Changes (LOW / defense-in-depth)

**`modules/cost.sh`** — `COST_MINIMUM_DISPLAY` is interpolated into a `bc` comparison (`echo "$session_cost >= $min_display" | bc -l`, :51) **unvalidated**, even though `COST_DECIMAL_PLACES` two lines up is already `safe_int`-guarded. A value like `COST_MINIMUM_DISPLAY=0.01 + 9999` is bc-evaluated and silently bypasses the display threshold (always-hide). Added a plain-decimal allowlist (`^[0-9]+(\.[0-9]+)?$` → else `0.01`). This is the direct sibling of the bc-sink validation #27 added.

**`modules/battery.sh`** — `BATTERY_LOW_THRESHOLD` / `BATTERY_CRITICAL_THRESHOLD` feed integer comparisons (`[ "$pct_num" -le "$crit_thresh" ]`) with no validation, unlike `cpu.sh` which routes its thresholds through `safe_int`/`get_status`. A non-numeric value breaks the battery icon logic. Wrapped both in `safe_int` (matches the `cpu.sh` pattern).

## Severity / scope honesty

**LOW.** The `load_config_safe()` parser already blocks command injection (rejects backtick, `$(`, `;`, `|`, `&`, `>`, `<`, and assigns via `printf -v %s` with no `eval`). So these are **logic-error / display gaps** from a malformed untrusted config — not code-exec. The parser itself is sound and **unchanged**. This PR just brings the two stragglers in line with the existing sink-validation discipline.

## Not in this PR (related LOW, deferred)

- `barista.sh` uses `TERMINAL_WIDTH` / `RIGHT_SIDE_RESERVE` directly in arithmetic (`$((term_width - right_reserve))`) at three read-sites without validation — a negative/non-numeric untrusted value causes wasteful padding (DoS-lite output bloat), not injection. Left for a focused follow-up since it spans multiple functions and a proper fix wants a positive-integer clamp, not just `safe_int` (which permits negatives).
- The parser's blocklist permits `$VAR`/`%`/glob/leading-`-`, but all current consumers use the values quoted/numerically, so there's no live exploit — noted, not changed.

## Verification
- `bash -n` clean; **shellcheck `--severity=error` gate clean**; **0 new advisory codes**; `tests/test_sandbox.sh` **4/4**; render smoke exit 0.
- Functional: `COST_MINIMUM_DISPLAY=0.01 + 9999` and `BATTERY_LOW_THRESHOLD=abc` now default safely; legit `0.05` / `15` pass.
