### PR TITLE
security(config): refuse to source group/world-writable barista.conf (Refs #28)

### DIFF
--- a/barista.sh
+++ b/barista.sh
@@ -84,10 +84,39 @@ RIGHT_SIDE_RESERVE=20        # Space reserved on right side of terminal (used by
 # CONFIGURATION LOADING
 # =============================================================================
 
+# Succeeds unless $1 is group- or world-writable. A barista.conf is sourced as full
+# bash, so a writable one is a persistent code-exec vector (Refs #28 part 3). Mirrors
+# the Darwin/Linux stat fork used in utils.sh; fails open if the mode can't be read so
+# an unusual environment never breaks the statusline.
+config_not_group_or_world_writable() {
+    local f="$1" perms len group_digit other_digit
+    if [ "$(uname)" = "Darwin" ]; then
+        perms=$(/usr/bin/stat -f '%Lp' "$f" 2>/dev/null)
+    else
+        perms=$(stat -c '%a' "$f" 2>/dev/null)
+    fi
+    [ -n "$perms" ] || return 0
+    len=${#perms}
+    group_digit="${perms:len-2:1}"
+    other_digit="${perms:len-1:1}"
+    # octal write bit is 2 (present in digits 2,3,6,7)
+    if (( (group_digit & 2) != 0 || (other_digit & 2) != 0 )); then
+        return 1
+    fi
+    return 0
+}
+
 # Load a trusted config file by sourcing it (only for configs we ship or the user owns)
 load_config() {
     local config_path="$1"
     if [ -f "$config_path" ]; then
+        # The file is sourced as full bash; refuse a group/world-writable one so a
+        # weak umask or shared install dir can't turn it into a code-exec path (#28).
+        if ! config_not_group_or_world_writable "$config_path"; then
+            [ "${DEBUG_MODE:-false}" = "true" ] && \
+                echo "barista: refusing to source group/world-writable config: $config_path" >&2
+            return 1
+        fi
         # shellcheck source=/dev/null
         . "$config_path"
         return 0


### PR DESCRIPTION
## Summary

Closes **part 3** of the #28 security umbrella — the script-dir and user `barista.conf` files are `source`d as full bash on every render with no permission check.

## The gap

`barista.sh` `load_config()` does `. "$config_path"` for BOTH `$SCRIPT_DIR/barista.conf` (shipped) and `$CLAUDE_CONFIG_DIR/barista.conf` (user). If either is **group- or world-writable** (weak umask, a shared install directory, a shared `$HOME`), anyone who can write to it gets **arbitrary bash executed on every statusline render**. The per-directory `.barista.conf` is already safe (it uses the non-sourcing `load_config_safe` parser); these two `source`-based paths were the gap.

> #28 **part 2** (settings.json heredoc) shipped in #29. **Part 1** (self-update integrity — sha256sums/GPG) remains open and author-gated on a release-process decision, so this PR uses `Refs #28`, not `Closes`.

## Fix

- New `config_not_group_or_world_writable()` helper: reads the file mode via the **shadow-safe** Darwin `/usr/bin/stat -f '%Lp'` / Linux `stat -c '%a'` fork — the same pattern `utils.sh` adopted in #18 — and returns failure if the group- or other-write bit is set.
- `load_config()` calls it before sourcing: a writable config is **skipped** (with a `DEBUG_MODE`-gated stderr note) instead of executed. **Fails open** if the mode can't be read, so an unusual filesystem never breaks the statusline.
- Bash 3.2-compatible (positive-offset substrings, `(( ))` arithmetic, no associative arrays). Only the two trusted `source` paths change; the untrusted-`.barista.conf` safe-parser path is untouched.

## Verification

- `shellcheck --severity=error` (with `.shellcheckrc`): **clean, rc=0** — 0 new findings.
- `bash -n`: clean. `tests/test_sandbox.sh`: **4/4**. Render smoke: **exit 0** (shipped config still sources).
- Functional: the guard **sources** `600 / 640 / 644 / 755` and **refuses** `660 / 664 / 666` (group/world-writable).

Refs #28
