### PR TITLE
security: clamp untrusted TERMINAL_WIDTH/RIGHT_SIDE_RESERVE arithmetic + chmod 700 cache dir

### DIFF
--- a/barista.sh
+++ b/barista.sh
@@ -473,6 +473,20 @@ main() {
         apply_theme
     fi
 
+    # Sanitize the untrusted-config width numerics before the layout arithmetic below.
+    # TERMINAL_WIDTH / RIGHT_SIDE_RESERVE are allowlisted from the untrusted project
+    # .barista.conf (loaded just above via the safe parser); a non-positive-integer or
+    # leading-zero ("octal") value would break the wrap math — e.g. TERMINAL_WIDTH="0"
+    # is a modulo-by-zero in the wrap layout, and "08" is a bash arithmetic error. Clamp
+    # once, after all configs load (mirrors the cost/battery config-sink validation).
+    case "${TERMINAL_WIDTH:-}" in
+        ''|*[!0-9]*|0*) TERMINAL_WIDTH="" ;;     # invalid → fall back to auto-detect
+    esac
+    case "${RIGHT_SIDE_RESERVE:-}" in
+        0) ;;                                     # zero is valid (no reserve)
+        ''|*[!0-9]*|0*) RIGHT_SIDE_RESERVE=20 ;;  # invalid/leading-zero → default
+    esac
+
     # Adjust separator based on display mode
     # Normal/verbose modes get padded separators, compact mode gets no padding
     if [ "${DISPLAY_MODE:-normal}" = "compact" ]; then

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -46,6 +46,12 @@ CACHE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/barista-cache"
 init_cache() {
     if [ ! -d "$CACHE_DIR" ]; then
         mkdir -p "$CACHE_DIR" 2>/dev/null
+        # Restrict to the owner so the cache dir can't be world-readable under a
+        # permissive umask — the cache key names (weather, wan_ip, update_check…)
+        # would otherwise leak config state to other local users. Cache files are
+        # already chmod 600 individually; this hardens the directory uniformly for
+        # every cache client (matches network.sh/weather.sh).
+        chmod 700 "$CACHE_DIR" 2>/dev/null
     fi
 }
 


### PR DESCRIPTION
## Summary

Two LOW defense-in-depth hardening fixes, both verified (bash -n / shellcheck error-gate / tests / render smoke / functional). The first completes the untrusted-config sink-validation theme from #27/#32 (the remaining width-arithmetic siblings — the deferred-LOW "next-touch" item); the second hardens the cache directory's permissions.

## 1. Clamp untrusted `TERMINAL_WIDTH` / `RIGHT_SIDE_RESERVE` before the width math (`barista.sh`)

Both are allowlisted from the **untrusted** project `.barista.conf` (safe-parsed, no source/eval) and then flowed **raw** into the layout arithmetic (`term_width`/`right_reserve` at ~391/526/564/594). The parser blocks injection but doesn't constrain these to sane integers, so a malformed value broke the wrap/truncate math:

- `TERMINAL_WIDTH=0` → `$((output_len % term_width))` = **modulo-by-zero**
- `TERMINAL_WIDTH`/`RIGHT_SIDE_RESERVE="08"` → bash **"value too great for base"** (leading zero parsed as octal)
- `"abc"` / `"-5"` → non-integer arithmetic

Fix: normalize both **once** in `main()`, right after all configs load + `apply_theme` (so all three downstream `term_width` derivations + the `right_reserve` reads get safe values). Invalid/non-positive/leading-zero `TERMINAL_WIDTH` → `""` (re-enables auto-detect); invalid/leading-zero `RIGHT_SIDE_RESERVE` → `20` (`0` kept). Bash 3.2 `case` globs. This is the established cost/battery (#27/#32) discipline applied to the width-arithmetic siblings.

## 2. `chmod 700` the cache dir in `init_cache()` (`modules/utils.sh`)

`init_cache()` created `$CACHE_DIR` with `mkdir -p` only — under a permissive umask the directory could be world-readable (0755). Cache **files** are written `chmod 600` individually, but a readable **directory** leaks the cache key names (`weather`, `wan_ip`, `update_check`, …) — config state — to other local users. `network.sh`/`weather.sh` already `chmod 700` after their own mkdir; this hardens the shared `init_cache()` so every cache client gets a 0700 dir uniformly.

## Severity

Both **LOW** defense-in-depth: #1 is a malformed-LOCAL-config → display/arithmetic glitch (stderr-suppressed), not code-exec (the parser already blocks injection); #2 is local cache-key-name disclosure (file contents already private).

## Verification

- `bash -n`: **29/29 clean**.
- `shellcheck --severity=error` (the repo's gate per `.shellcheckrc`): **0 errors**, and the full advisory composition is **unchanged** (no new codes from the new `case` blocks or the `chmod`).
- `tests/test_sandbox.sh`: **4/4 pass**.
- Render smoke (`echo '{}' | barista.sh`): exit 0.
- **Functional clamp test**: `TERMINAL_WIDTH=0`/`abc`/`-5` + `RIGHT_SIDE_RESERVE=08` (with `LAYOUT_MODE=wrap`) now render with **no arithmetic error** (the pre-fix modulo-by-zero/octal-trap are gone); a legit `TERMINAL_WIDTH=120`/`RIGHT_SIDE_RESERVE=15` still renders normally.
- Diff: 2 files, +20/−0.

No `Fixes #` — untracked LOW hardening (the TERMINAL_WIDTH item was the dossier-tracked deferred-LOW from PR #32; the cache-dir perms is a fresh find this scan).
