### PR TITLE
fix(temperature): use the module's own thresholds for the status indicator

### DIFF
--- a/modules/temperature.sh
+++ b/modules/temperature.sh
@@ -67,7 +67,7 @@ module_temperature() {
     local result="$icon ${display_temp}°${units}"
 
     if [ "$show_status" = "true" ]; then
-        local status_ind=$(get_status "$temp_int" "${TEMP_WARNING_THRESHOLD:-70}" "${TEMP_CRITICAL_THRESHOLD:-85}")
+        local status_ind=$(get_status "$display_temp" "$warn_thresh" "$crit_thresh")
         result="$result${status_ind}"
     fi
 


### PR DESCRIPTION
## Summary

Autonomous scan of **Barista** (HEAD `ac03d8f`). The security / config-sink / injection surface is exhausted-clean across ~6 prior scans, so this scan took a fresh **module-robustness** angle (missing-tool / empty-output / arithmetic / cross-platform across the ~20 segment modules). The modules are robust — all guard their tools and arithmetic. The one real, scan-sized fix is a threshold-wiring inconsistency in `temperature.sh`.

## The issue (`modules/temperature.sh`)

`module_temperature` computes local thresholds the same way every sibling module does:

```sh
local warn_thresh=$(safe_int "${TEMP_WARNING_THRESHOLD:-70}" 70)
local crit_thresh=$(safe_int "${TEMP_CRITICAL_THRESHOLD:-85}" 85)
# …and converts both to Fahrenheit when TEMP_UNITS=F
```

…but the status-indicator call **ignored those locals** and passed the raw env values against the Celsius `temp_int`:

```sh
local status_ind=$(get_status "$temp_int" "${TEMP_WARNING_THRESHOLD:-70}" "${TEMP_CRITICAL_THRESHOLD:-85}")
```

So the safe_int'd / Fahrenheit-converted thresholds were **dead code**, and `temperature.sh` was the only module not following the sibling pattern (`context`/`processes`/`load`/`rate-limits` all pass their local `warn_thresh`/`crit_thresh`).

> Note: this is **not** a visible color bug today — the old call compared Celsius-temp vs Celsius-thresholds, which is internally consistent (the displayed °F value's color was still physically correct). The fix is a consistency / dead-code / robustness improvement, not a user-visible regression fix.

## The fix (1 line)

```sh
local status_ind=$(get_status "$display_temp" "$warn_thresh" "$crit_thresh")
```

- **Color-neutral for valid configs** — a Fahrenheit comparison (e.g. 167 vs 158/185) yields the same indicator as the Celsius one (75 vs 70/85). Verified: `get_status 75 70 85` = 🟡 ≡ `get_status 167 158 185` = 🟡; `get_status 60 70 85` = 🟢 ≡ `get_status 140 158 185` = 🟢.
- **F-mode now compares in the displayed unit** (the previously-dead conversion is used), instead of silently comparing Celsius.
- **Correct default on a malformed threshold** — `safe_int(...,70/85)` instead of `get_status`'s generic 60/80 fallback when `TEMP_WARNING_THRESHOLD` is non-numeric.
- **Removes the dead-variable smell** and conforms to every sibling module.

## Verification
- `bash -n` clean; `shellcheck --severity=error` gate **exit 0** (the repo gate; no new advisory code); `temperature.sh` now has **0 advisories**.
- `tests/test_sandbox.sh` **4/4**; render smoke (empty + realistic + the `TEMP_UNITS=F` status path) all exit 0.

## Fresh-angle review — verified clean (not shipped)
- All ~20 modules guard their external tools (`command -v` / OS forks) and degrade silently when a tool is absent — no error spew into the statusline.
- Arithmetic is safe (`safe_int`/`safe_percent`, default-guarded divisors); no module div-by-zero or octal trap on empty tool output.
- Cross-platform `stat`/`date`/`df`/`ps`/`vm_stat` forks are BSD/GNU-correct; no bash-4-only constructs (`${var^^}` / `declare -A` / `mapfile`) — bash 3.2 compatible. (A reviewer pass flagged `[[ … =~ … ]]` as "bash 4+"; that's incorrect — `[[ ]]`/`=~` are bash 3.0+ and used throughout, so not changed.)
