### PR TITLE
test(utils): regression tests for get_status / safe_percent / progress_bar

### DIFF
--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# ABOUTME: Tests for the shared utils.sh status/percentage/progress-bar helpers used across modules
+# ABOUTME: Run with: bash tests/test_utils.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected: '$expected'"
+        echo "    actual:   '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Load utils (the functions under test)
+. "$SCRIPT_DIR/modules/utils.sh"
+
+# -----------------------------------------------------------------------------
+# get_status <value> <warning> <critical>
+# 3-level threshold: value >= critical -> red, value >= warning -> yellow, else green.
+# Uses >= at BOTH boundaries; prefixes a space unless DISPLAY_MODE=compact.
+# -----------------------------------------------------------------------------
+echo "=== get_status Tests ==="
+# Isolate from any theme/global state so the :- defaults apply deterministically.
+unset STATUS_GREEN STATUS_YELLOW STATUS_RED STATUS_ORANGE
+USE_STATUS_INDICATORS="true"
+DISPLAY_MODE="compact"      # prefix = "" so the output is exactly the indicator
+STATUS_STYLE="ascii"        # [OK] / [WARN] / [CRIT] — deterministic, no emoji bytes
+
+assert_eq "below warning is green"              "[OK]"   "$(get_status 50 60 80)"
+assert_eq "exactly at warning is yellow (>=)"   "[WARN]" "$(get_status 60 60 80)"
+assert_eq "between warning and critical is yellow" "[WARN]" "$(get_status 70 60 80)"
+assert_eq "exactly at critical is red (>=)"     "[CRIT]" "$(get_status 80 60 80)"
+assert_eq "above critical is red"               "[CRIT]" "$(get_status 85 60 80)"
+
+# Default thresholds when omitted are warning=60, critical=80.
+assert_eq "default thresholds: 50 -> green"  "[OK]"   "$(get_status 50)"
+assert_eq "default thresholds: 65 -> yellow" "[WARN]" "$(get_status 65)"
+assert_eq "default thresholds: 90 -> red"    "[CRIT]" "$(get_status 90)"
+
+# Non-compact display modes prefix a single space before the indicator.
+DISPLAY_MODE="normal"
+assert_eq "normal mode prefixes a space" " [OK]" "$(get_status 50 60 80)"
+DISPLAY_MODE="compact"
+
+# Emoji is the default style; a mid-range value selects the yellow indicator.
+STATUS_STYLE="emoji"
+assert_eq "emoji style yields the yellow dot" "🟡" "$(get_status 70 60 80)"
+STATUS_STYLE="ascii"
+
+# Indicators can be disabled entirely.
+USE_STATUS_INDICATORS="false"
+assert_eq "disabled indicators yield empty string" "" "$(get_status 90 60 80)"
+USE_STATUS_INDICATORS="true"
+
+# -----------------------------------------------------------------------------
+# safe_percent <value> <total> [default]
+# value*100/total (integer), guarding divide-by-zero with the default.
+# -----------------------------------------------------------------------------
+echo "=== safe_percent Tests ==="
+assert_eq "50 of 100 is 50"                      "50"  "$(safe_percent 50 100)"
+assert_eq "divide-by-zero returns the default"   "99"  "$(safe_percent 10 0 99)"
+assert_eq "integer division truncates (1/3)"     "33"  "$(safe_percent 1 3)"
+assert_eq "non-numeric value coerces to 0"       "0"   "$(safe_percent abc 100)"
+assert_eq "does not clamp above 100"             "200" "$(safe_percent 200 100)"
+
+# -----------------------------------------------------------------------------
+# progress_bar <percent> <width> [filled_char] [empty_char]
+# filled = percent*width/100; clamps percent to [0,100]; width<=0 falls back to 8.
+# (ASCII fill chars keep the assertions free of multi-byte glyph width issues.)
+# -----------------------------------------------------------------------------
+echo "=== progress_bar Tests ==="
+assert_eq "0 percent is all empty"          "--------" "$(progress_bar 0 8 '#' '-')"
+assert_eq "50 percent is half filled"       "####----" "$(progress_bar 50 8 '#' '-')"
+assert_eq "100 percent is all filled"       "########" "$(progress_bar 100 8 '#' '-')"
+assert_eq "over 100 clamps to full"         "########" "$(progress_bar 125 8 '#' '-')"
+assert_eq "negative clamps to empty"        "--------" "$(progress_bar -5 8 '#' '-')"
+assert_eq "width <= 0 falls back to 8"      "####----" "$(progress_bar 50 0 '#' '-')"
+assert_eq "fill count truncates (33%->2)"   "##------" "$(progress_bar 33 8 '#' '-')"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Adds regression test coverage for the shared `modules/utils.sh` helpers. Before this, the repo's only test file (`tests/test_sandbox.sh`) covered just the `sandbox` module — **1 of 26 modules (~4%)** — while the cross-cutting utility functions that drive most modules' display had no tests at all. The `get_status` threshold logic in particular was a live bug as recently as #35 (temperature status used the wrong thresholds), yet nothing guards it against regression.

This scan's review otherwise found no shippable bug (the security/config-sink/module-robustness surfaces remain exhausted-clean; see "What Was NOT Changed"), so a test-coverage slice on the most-reused logic is the highest-value engagement.

## Changes Made

**New `tests/test_utils.sh`** (mirrors the existing `test_sandbox.sh` harness — `assert_eq`, PASS/FAIL counters, sources `modules/utils.sh`). **23 hand-computed ground-truth assertions** over three pure functions:

- **`get_status <value> <warning> <critical>`** — the 3-level green/yellow/red indicator used by temperature, load, cpu, memory, disk:
  - both `>=` boundaries (`value == warning` → yellow, `value == critical` → red),
  - the default `60` / `80` thresholds when args are omitted,
  - the compact-vs-normal space prefix (`DISPLAY_MODE`),
  - emoji vs ascii style (`STATUS_STYLE`),
  - the `USE_STATUS_INDICATORS=false` disable path.
- **`safe_percent <value> <total> [default]`** — `value*100/total`, the divide-by-zero default, integer truncation (`1/3 → 33`), non-numeric coercion to 0, and that it does **not** clamp above 100.
- **`progress_bar <percent> <width>`** — the fill math, `[0,100]` clamping (negative and over-100), and the `width<=0 → 8` fallback. (ASCII fill chars are passed so the assertions avoid multi-byte glyph-width issues.)

## What Was NOT Changed

- **No production code touched** — tests only; zero behavior change.
- **Latent ANSI truncation note (for the human, not fixed):** in `barista.sh`'s `truncate` layout mode, `truncate_at` is computed from the ANSI-stripped *visible* length but applied as an offset on the *raw* string. This is **not reachable today** — no module emits ANSI escape sequences (status indicators are emoji/ASCII, which bash's character-based substring handles correctly). It would only matter if a future color-theme feature emitted in-band ANSI. Flagged here rather than "fixed" to avoid churn on a non-reachable path.
- **Open issues** (#26 git TTL-cache, #24 config TUI, #23 Homebrew/npx) remain feature/author-gated.

## Verification

- `bash tests/test_utils.sh` → **23 / 23 pass**, exit 0.
- **Non-tautological** — flipping `get_status`'s critical comparison from `-ge` to `-gt` makes the "exactly at critical is red" case fail (22/1), then restoring returns it to 23/23. The tests are coupled to the implementation's boundary semantics.
- `bash -n` clean across all **30** `.sh` files.
- `shellcheck --severity=error` → **0** (the repo's `.shellcheckrc` gate).
- `tests/test_sandbox.sh` still **4 / 4**; `echo '{}' | bash barista.sh` exit 0.

Adds: regression coverage for the shared utils status/percent/bar helpers.
