### PR TITLE
fix(rate-limits): parse resets_at with GNU date so time-remaining shows on Linux/Windows

### DIFF
--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -192,6 +192,16 @@ _get_projection_status() {
     get_status "$projected" "$warn_thresh" "$crit_thresh"
 }
 
+# Parse an ISO-8601 resets_at timestamp (UTC, fractional seconds stripped by the
+# caller) to epoch seconds. `date -j -f` is BSD/macOS-only; GNU date (Linux,
+# Git Bash on Windows) needs -d. Try both so time-remaining works everywhere.
+_parse_reset_epoch() {
+    local ts="$1"
+    date -u -j -f "%Y-%m-%dT%H:%M:%S" "$ts" +%s 2>/dev/null || \
+        date -u -d "$ts" +%s 2>/dev/null || \
+        echo 0
+}
+
 module_rate_limits() {
     local show_5h="${RATE_SHOW_5H:-true}"
     local show_7d="${RATE_SHOW_7D:-true}"
@@ -310,7 +320,7 @@ module_rate_limits() {
 
     # Parse 5-hour reset time and calculate projection
     if [ -n "$five_hour_reset" ]; then
-        local five_hour_reset_epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%S" "${five_hour_reset%%.*}" +%s 2>/dev/null || echo 0)
+        local five_hour_reset_epoch=$(_parse_reset_epoch "${five_hour_reset%%.*}")
         five_hour_remaining=$((five_hour_reset_epoch - now))
         if [ "$five_hour_remaining" -gt 18000 ]; then
             five_hour_remaining=18000
@@ -342,7 +352,7 @@ module_rate_limits() {
 
     # Parse 7-day reset time and calculate projection
     if [ -n "$seven_day_reset" ]; then
-        local seven_day_reset_epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%S" "${seven_day_reset%%.*}" +%s 2>/dev/null || echo 0)
+        local seven_day_reset_epoch=$(_parse_reset_epoch "${seven_day_reset%%.*}")
         seven_day_remaining=$((seven_day_reset_epoch - now))
         if [ "$seven_day_remaining" -gt 604800 ]; then
             seven_day_remaining=604800


### PR DESCRIPTION
## Summary

`RATE_SHOW_TIME_REMAINING` (default: `true`) never displays anything on Linux or Windows (Git Bash). The `resets_at` timestamps are parsed only with BSD date syntax:

```sh
date -u -j -f "%Y-%m-%dT%H:%M:%S" "${five_hour_reset%%.*}" +%s 2>/dev/null || echo 0
```

GNU date doesn't support `-j`/`-f`, so this silently falls back to epoch `0`, the computed remaining time goes negative, and the `(2h 15m)` / `(3d 4h)` suffix is skipped — with no error, since stderr is discarded. macOS users are unaffected.

## Fix

Adds a small `_parse_reset_epoch` helper that tries BSD `date -j -f` first (macOS), then GNU `date -d` (Linux, Git Bash), keeping `0` as the final fallback. Both call sites (5-hour and 7-day) now use it. No behavior change on macOS.

## Testing

- On Git Bash (Windows): before the fix, output was `5h:24% 🟢 7d:71% 🟡`; after, `5h:24% 🟢 (2h 4m) 7d:71% 🟡 (3d 21h)`.
- Verified the BSD branch is attempted first and the GNU fallback only runs when `-j` is unsupported.
- `bash tests/test_utils.sh` and `bash tests/test_sandbox.sh` pass (27/27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)