### PR TITLE
test(utils): regression tests for the remaining pure utils.sh helpers

### DIFF
--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# ABOUTME: Tests for the shared utils.sh status/percentage/progress-bar helpers used across modules
+# ABOUTME: Tests for the shared utils.sh helpers (status, percentage, progress bar, number/time
+# ABOUTME: formatting, safe int/divide, string truncation, icon + display-mode checks) used across modules
 # ABOUTME: Run with: bash tests/test_utils.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -84,6 +85,111 @@ assert_eq "over 100 clamps to full"         "########" "$(progress_bar 125 8 '#'
 assert_eq "negative clamps to empty"        "--------" "$(progress_bar -5 8 '#' '-')"
 assert_eq "width <= 0 falls back to 8"      "####----" "$(progress_bar 50 0 '#' '-')"
 assert_eq "fill count truncates (33%->2)"   "##------" "$(progress_bar 33 8 '#' '-')"
+
+# -----------------------------------------------------------------------------
+# safe_int <value> [default]
+# Strips a trailing ".xxx" decimal, then accepts only ^-?[0-9]+$; otherwise the
+# default (which itself defaults to 0). Empty / "null" / "undefined" -> default.
+# -----------------------------------------------------------------------------
+echo "=== safe_int Tests ==="
+assert_eq "plain integer passes through"       "100" "$(safe_int 100)"
+assert_eq "decimal portion is stripped"        "100" "$(safe_int 100.7)"
+assert_eq "empty value uses default 0"         "0"   "$(safe_int '')"
+assert_eq "empty value uses supplied default"  "5"   "$(safe_int '' 5)"
+assert_eq "literal null uses default"          "0"   "$(safe_int null)"
+assert_eq "non-numeric uses supplied default"  "7"   "$(safe_int abc 7)"
+assert_eq "negative integer is accepted"       "-42" "$(safe_int -42)"
+assert_eq "trailing garbage is rejected"       "0"   "$(safe_int 12abc)"
+
+# -----------------------------------------------------------------------------
+# safe_divide <num> <denom> [default]
+# Integer num/denom. denom defaults to 1 when empty (so an empty denom is NOT a
+# zero-divide); a zero denom returns the default (default itself defaults to 0).
+# -----------------------------------------------------------------------------
+echo "=== safe_divide Tests ==="
+assert_eq "even division"                       "25"  "$(safe_divide 100 4)"
+assert_eq "integer division truncates"          "3"   "$(safe_divide 7 2)"
+assert_eq "zero denom returns default 0"        "0"   "$(safe_divide 100 0)"
+assert_eq "zero denom returns supplied default" "99"  "$(safe_divide 100 0 99)"
+assert_eq "empty denom defaults to 1 not zero"  "100" "$(safe_divide 100 '')"
+assert_eq "negative numerator"                  "-25" "$(safe_divide -100 4)"
+assert_eq "zero numerator"                      "0"   "$(safe_divide 0 5)"
+
+# -----------------------------------------------------------------------------
+# truncate_string <string> <max_len>
+# When ${#str} > max_len (and max_len > 0): first (max_len-3) chars + "...".
+# Otherwise the string is returned unchanged. max_len <= 3 is pathological
+# (it would index with a negative length) and intentionally untested -- real
+# callers pass widths >= 4.
+# -----------------------------------------------------------------------------
+echo "=== truncate_string Tests ==="
+assert_eq "shorter than max is unchanged"      "hello"    "$(truncate_string hello 10)"
+assert_eq "equal to max is unchanged"          "hello"    "$(truncate_string hello 5)"
+assert_eq "longer than max keeps max-3 + dots" "hello..." "$(truncate_string 'hello world' 8)"
+assert_eq "max_len 4 keeps one char + dots"    "h..."     "$(truncate_string hello 4)"
+assert_eq "ten chars to width 7"               "abcd..."  "$(truncate_string abcdefghij 7)"
+assert_eq "max_len 0 disables truncation"      "hi"       "$(truncate_string hi 0)"
+
+# -----------------------------------------------------------------------------
+# format_time_remaining <seconds>
+# <=0 -> "now"; days>0 -> "Nd Nh"; else hours>0 -> "Nh Nm"; else "Nm".
+# Sub-minute values render as "0m" (there is no seconds unit).
+# -----------------------------------------------------------------------------
+echo "=== format_time_remaining Tests ==="
+assert_eq "zero is now"               "now"   "$(format_time_remaining 0)"
+assert_eq "negative is now"           "now"   "$(format_time_remaining -10)"
+assert_eq "sub-minute is 0m"          "0m"    "$(format_time_remaining 30)"
+assert_eq "exactly one minute"        "1m"    "$(format_time_remaining 60)"
+assert_eq "minutes only"              "9m"    "$(format_time_remaining 599)"
+assert_eq "exactly one hour shows 0m" "1h 0m" "$(format_time_remaining 3600)"
+assert_eq "hours and minutes"         "2h 2m" "$(format_time_remaining 7320)"
+assert_eq "exactly one day shows 0h"  "1d 0h" "$(format_time_remaining 86400)"
+assert_eq "days and hours"            "1d 1h" "$(format_time_remaining 90061)"
+
+# -----------------------------------------------------------------------------
+# format_number <num>
+# >=1,000,000 -> "<n>M"; >=1,000 -> "<n>k"; else the number. Integer division
+# truncates (no rounding); the suffixes are lowercase k / uppercase M.
+# -----------------------------------------------------------------------------
+echo "=== format_number Tests ==="
+assert_eq "below 1k is unchanged"   "999"  "$(format_number 999)"
+assert_eq "exactly 1000 is 1k"      "1k"   "$(format_number 1000)"
+assert_eq "thousands truncate"      "1k"   "$(format_number 1999)"
+assert_eq "tens of thousands"       "12k"  "$(format_number 12345)"
+assert_eq "just under a million"    "999k" "$(format_number 999999)"
+assert_eq "exactly a million is 1M" "1M"   "$(format_number 1000000)"
+assert_eq "millions truncate"       "2M"   "$(format_number 2500000)"
+assert_eq "zero is unchanged"       "0"    "$(format_number 0)"
+
+# -----------------------------------------------------------------------------
+# get_icon <icon> [fallback]
+# Echoes the icon when USE_ICONS != "false" (default true), else the fallback
+# (which itself defaults to empty).
+# -----------------------------------------------------------------------------
+echo "=== get_icon Tests ==="
+USE_ICONS="true"
+assert_eq "icons on returns the icon"     "ICON" "$(get_icon ICON FB)"
+USE_ICONS="false"
+assert_eq "icons off returns fallback"    "FB"   "$(get_icon ICON FB)"
+assert_eq "icons off, no fallback, empty" ""     "$(get_icon ICON)"
+unset USE_ICONS
+assert_eq "icons default on returns icon" "ICON" "$(get_icon ICON FB)"
+USE_ICONS="true"
+
+# -----------------------------------------------------------------------------
+# is_compact [module_flag] / is_verbose -- return-code helpers keyed on
+# DISPLAY_MODE. is_compact is additionally true when its module-flag arg == "true".
+# -----------------------------------------------------------------------------
+echo "=== is_compact / is_verbose Tests ==="
+DISPLAY_MODE="normal"
+assert_eq "normal mode is not compact" "no"  "$(is_compact && echo yes || echo no)"
+assert_eq "module flag forces compact" "yes" "$(is_compact true && echo yes || echo no)"
+DISPLAY_MODE="compact"
+assert_eq "compact mode is compact"    "yes" "$(is_compact && echo yes || echo no)"
+DISPLAY_MODE="verbose"
+assert_eq "verbose mode is verbose"    "yes" "$(is_verbose && echo yes || echo no)"
+DISPLAY_MODE="normal"
+assert_eq "normal mode is not verbose" "no"  "$(is_verbose && echo yes || echo no)"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

A scan of Barista (pure-Bash Claude Code statusline). The code is in excellent shape — QA is green (bash -n 30/30, shellcheck error-gate 0, render exit 0) and a fresh full-surface security/correctness pass over barista.sh + every module except the in-flight `rate-limits.sh` found **0 new issues** (the security/config/module-robustness surface has been exhausted across prior scans). The productive axis here remains **test coverage**: before #36 the shared `modules/utils.sh` helpers had zero tests; #36 locked 3 of them, and this PR extends that to the rest of the pure, deterministic helpers.

## Changes Made

**`tests/test_utils.sh`** — +47 ground-truth assertions (23 → 70 total), no production code touched.

- **What:** New test sections for `safe_int`, `safe_divide`, `format_number`, `format_time_remaining`, `truncate_string`, `get_icon`, and `is_compact`/`is_verbose`.
- **Why:** These are cross-module helpers (number/time formatting, safe arithmetic, string truncation, display-mode checks) used throughout the modules; a silent regression in any of them would corrupt many statusline segments at once, with nothing to catch it.
- **How:** Each assertion encodes a specific documented behavior or edge case, hand-derived from the `utils.sh` source — e.g. `safe_divide`'s empty denominator defaults to **1** (not a zero-divide); `format_number` truncates (`1999 → 1k`); `format_time_remaining` renders sub-minute values as `0m` and `<=0` as `now`; `truncate_string` keeps `max_len-3` chars + `...`.
- **Impact:** 70/70 pass. Coverage of the pure `utils.sh` surface goes from 3 helpers to 11.

**Non-tautology check:** verified these assertions actually fail when logic changes — flipping `format_number`'s `-ge 1000` boundary to `-gt 1000` makes the "exactly 1000 is 1k" assertion fail; restored after.

## What Was NOT Changed

- **`modules/rate-limits.sh`** — left untouched: PRs **#37** (5h/7d progress bars) and **#38** (GNU-date `resets_at` parsing) are in flight there. Testing that surface now would risk churn against those PRs; deferred until they land.
- **`json_get` / `json_get_int`** — untested here on purpose: they shell out to `jq` (not pure), so they belong in a separate jq-guarded test group rather than mixed into the pure-helper suite.
- **`truncate_string` with `max_len <= 3`** — produces a negative substring length (`${str:0:-1}`), which is fragile on bash 3.2. Only reachable via a pathological width config; not "fixed" (anti-churn) and not tested. Flagged for a separate hardening decision.
- **Security / config / module-robustness** — no new findings; this surface has been exhausted across prior scans (safe config parser, #33 perms guard, #34 clamps, #27/#32 config sinks). Not re-flagged.

## Verification

- `bash -n` (all 30 shell files): **0 failures**
- `shellcheck --severity=error`: **0** error-level findings (below-gate codes are intentional author policy)
- `bash tests/test_sandbox.sh`: **4/4**
- `bash tests/test_utils.sh`: **70/70**
- render smoke (`echo '{}' | bash barista.sh`): **exit 0**

Adds: regression coverage for the pure `modules/utils.sh` helpers (no linked issue — continues the #36 coverage effort).
