### PR TITLE
test(utils): regression-lock json_get / json_get_int (70 -> 83)

### DIFF
--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -191,6 +191,28 @@ assert_eq "verbose mode is verbose"    "yes" "$(is_verbose && echo yes || echo n
 DISPLAY_MODE="normal"
 assert_eq "normal mode is not verbose" "no"  "$(is_verbose && echo yes || echo no)"
 
+# -----------------------------------------------------------------------------
+# json_get <json> <path> [default] / json_get_int <json> <path> [default]
+# jq extraction with a default fallback. Empty or "null" json short-circuits to
+# the default (no jq call). Otherwise `jq -r "<path> // empty"`, and an
+# empty / null / missing result falls back to the default. json_get_int
+# additionally coerces through safe_int (non-numeric -> default). Requires jq.
+# -----------------------------------------------------------------------------
+echo "=== json_get / json_get_int Tests ==="
+assert_eq "json_get extracts a string value"           "bar" "$(json_get '{"foo":"bar"}' '.foo' 'def')"
+assert_eq "json_get extracts a nested value"           "c"   "$(json_get '{"a":{"b":"c"}}' '.a.b' 'def')"
+assert_eq "json_get returns a numeric value as text"   "42"  "$(json_get '{"n":42}' '.n' 'def')"
+assert_eq "json_get missing key falls back to default" "def" "$(json_get '{"foo":"bar"}' '.missing' 'def')"
+assert_eq "json_get json null literal -> default"      "def" "$(json_get 'null' '.foo' 'def')"
+assert_eq "json_get empty json -> default"             "def" "$(json_get '' '.foo' 'def')"
+assert_eq "json_get explicit-null field -> default"    "def" "$(json_get '{"foo":null}' '.foo' 'def')"
+assert_eq "json_get malformed json -> default"         "def" "$(json_get 'not json' '.foo' 'def')"
+assert_eq "json_get omitted default is empty"          ""    "$(json_get '{}' '.missing')"
+assert_eq "json_get_int extracts an integer"           "42"  "$(json_get_int '{"n":42}' '.n')"
+assert_eq "json_get_int non-numeric -> default 0"      "0"   "$(json_get_int '{"n":"x"}' '.n')"
+assert_eq "json_get_int missing -> explicit default"   "5"   "$(json_get_int '{}' '.n' '5')"
+assert_eq "json_get_int omitted default is 0"          "0"   "$(json_get_int '{}' '.n')"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Continues the test-coverage campaign (#36, #39) — regression-locks the two JSON-extraction helpers `json_get` / `json_get_int` (`modules/utils.sh`), which had **zero coverage** despite feeding every input-dependent module (context / model / cost parse the Claude Code session JSON through them). **No production code touched.**

## Changes Made

`tests/test_utils.sh` +13 ground-truth asserts (70 → **83**):

- **`json_get`** — string / nested / numeric extraction; and the full fallback contract: **missing key, explicit-`null` field, empty json, json `"null"` literal, and malformed json all fall back to the default**; omitted default is the empty string.
- **`json_get_int`** — integer extraction; non-numeric → default; missing → explicit / omitted default (via the already-locked `safe_int` coercion).

## How the expectations were derived

Per this repo's history of delegated agents reporting **wrong computed I/O** (e.g. `truncate_string` "e..." vs the real "h..."), every expected value was **confirmed empirically against the live functions** (jq present in CI/dev), not hand-guessed.

**Non-tautology proven:** temporarily disabling `json_get`'s value→default fallback (`if false`) made *exactly* the 3 fallback asserts fail (missing-key / null-field / malformed, all expecting `def`), the rest passing; reverted → 83/83.

## What Was NOT Changed

- **`modules/rate-limits.sh`** — left untouched; PRs **#37** (progress bars) and **#38** (GNU-date parsing) are in flight there. Rate-limit coverage waits until those land (anti-churn).
- No production code; the cache helpers (`init_cache`/`cache_get`/`cache_set`) are the next coverage target (need a tmp-sandbox harness).

## Verification

- `bash -n tests/test_utils.sh` — clean
- `shellcheck --severity=error tests/test_utils.sh` — 0
- `bash tests/test_utils.sh` — **83 / 83**
- `bash tests/test_sandbox.sh` — 4 / 4
- `echo '{}' | bash barista.sh` — exit 0 (render unaffected)
