### PR TITLE
test(project): regression-lock _get_project_icon + _format_project helpers

### DIFF
--- a/tests/test_project.sh
+++ b/tests/test_project.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# ABOUTME: Tests for modules/project.sh _get_project_icon and _format_project -- the two pure
+# ABOUTME: helpers behind the project module. _get_project_icon maps a detected project type to
+# ABOUTME: its icon, letting a per-type PROJECT_ICON_<TYPE> env var override the built-in default
+# ABOUTME: (and falling back to the default for unknown types). _format_project renders "icon name"
+# ABOUTME: per PROJECT_STYLE (icon/text/both), with USE_ICONS=false short-circuiting to name-only.
+# ABOUTME: Run with: bash tests/test_project.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected: '$expected'"
+        echo "    actual:   '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Load the module under test. _get_project_icon and _format_project are pure (case + echo, no I/O).
+# ASCII sentinels (DEF/OVR/ICON/NAME) keep assertions byte-clean instead of hinging on emoji bytes.
+. "$SCRIPT_DIR/modules/project.sh"
+
+# --- _get_project_icon <type> <default> ---------------------------------------
+# A known type with no override echoes the caller's default icon.
+assert_eq "known type, no override -> default" "DEF" "$(_get_project_icon nuxt DEF)"
+# A per-type override wins over the default -- this override is the whole point of the helper.
+assert_eq "override wins over default"         "OVR" "$(PROJECT_ICON_NUXT=OVR _get_project_icon nuxt DEF)"
+# Each type reads its OWN env var (not one shared var): swift honors PROJECT_ICON_SWIFT.
+assert_eq "swift reads PROJECT_ICON_SWIFT"     "S"   "$(PROJECT_ICON_SWIFT=S _get_project_icon swift DEF)"
+# The last case in the ladder (bun) still resolves -- proves the whole case reaches the end.
+assert_eq "bun (last case) -> default"         "DEF" "$(_get_project_icon bun DEF)"
+# An unrecognized type falls through the '*' branch to the default.
+assert_eq "unknown type -> default"            "DEF" "$(_get_project_icon cobol DEF)"
+# The override is type-scoped: setting nuxt's icon must NOT bleed into a go lookup.
+assert_eq "override does not leak across types" "DEF" "$(PROJECT_ICON_NUXT=OVR _get_project_icon go DEF)"
+
+# --- _format_project <icon> <name> --------------------------------------------
+# Default style (no PROJECT_STYLE) is "both": "icon name".
+assert_eq "default style -> both"       "ICON NAME" "$(_format_project ICON NAME)"
+assert_eq "style=both -> icon name"     "ICON NAME" "$(PROJECT_STYLE=both _format_project ICON NAME)"
+assert_eq "style=icon -> icon only"     "ICON"      "$(PROJECT_STYLE=icon _format_project ICON NAME)"
+assert_eq "style=text -> name only"     "NAME"      "$(PROJECT_STYLE=text _format_project ICON NAME)"
+# An unknown style falls through '*' to both -- pins that garbage renders "icon name", not empty.
+assert_eq "unknown style falls to both" "ICON NAME" "$(PROJECT_STYLE=bogus _format_project ICON NAME)"
+# USE_ICONS=false short-circuits to name-only BEFORE the style case -- it wins even over style=icon.
+assert_eq "USE_ICONS=false beats style=icon" "NAME" "$(USE_ICONS=false PROJECT_STYLE=icon _format_project ICON NAME)"
+assert_eq "USE_ICONS=false, default style"   "NAME" "$(USE_ICONS=false _format_project ICON NAME)"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Regression-locks the two pure helpers in `modules/project.sh` — `_get_project_icon` (per-type icon override) and `_format_project` (style rendering) — the last untested pure helpers in the module set. Test-only; HEAD byte-stable since #47.

## Changes Made
- **What:** new `tests/test_project.sh` (13 asserts, run-by-name — no glob runner, per the repo's no-CI fleet policy; `. "$SCRIPT_DIR/modules/project.sh"` is defs-only source, safe).
- **Why:** both helpers were untested (0 refs anywhere under `tests/`), yet each encodes a non-obvious contract:
  - `_get_project_icon <type> <default>` resolves a detected project type to its icon, letting a **per-type** `PROJECT_ICON_<TYPE>` env var override the built-in default — and each type reads its *own* var (no cross-type leak), with unknown types falling through to the default.
  - `_format_project <icon> <name>` renders per `PROJECT_STYLE` (`icon`/`text`/`both`, unknown→both), but `USE_ICONS=false` **short-circuits to name-only before the style case** — i.e. `USE_ICONS` wins even over `PROJECT_STYLE=icon`.
- **How — non-tautological, mutation-proven (ASCII sentinels keep asserts byte-clean, no emoji-byte flakiness):**
  - `_get_project_icon`: default (no override) → default; **override wins**; each type reads its own var (`PROJECT_ICON_SWIFT`); last case (`bun`) resolves; unknown → default; **override is type-scoped (no leak)**.
  - `_format_project`: default→both, `both`/`icon`/`text`, **unknown style falls to both (not empty)**, and **`USE_ICONS=false` beats `style=icon`**.
  - Verified: dropping the `nuxt` override (`${PROJECT_ICON_NUXT:-$default_icon}`→`$default_icon`) fails **only** the override-wins assert (leak-test stays green); dropping the icon from the both-branch (`echo "$icon $name"`→`echo "$name"`) fails **exactly** the 3 both-family asserts (icon/text/`USE_ICONS` stay green). `modules/project.sh` restored byte-identical after each.

## Verification
- `bash -n tests/test_project.sh` clean; `shellcheck --severity=error tests/test_project.sh` → **0** (below-error findings are author-policy per fleet convention, not regressions).
- `bash tests/test_project.sh` → **13 passed, 0 failed**.
- Full regression (run-by-name, no CI): sandbox 4 · utils 94 · cache 14 · rate-limits 13 · update 8 · uptime 9 = **142/142**, unchanged. `echo '{}' | bash barista.sh` → exit 0.

## What Was NOT Changed
- No production code touched (test-only). The remaining untested helpers are lower-value / harder to unit-test in isolation: `apply_theme` (~40 globals, bulky), `log_debug` (file-I/O), `_file_mtime`/`_file_size` (thin `stat` wrappers). This continues the #39–#47 pure-helper coverage vein; after these the pure-unit surface is effectively exhausted → verification-tier unless a new helper lands.
- 3 open issues (#23 Homebrew / #24 TUI / #26 git-TTL) are feature/author-judgment items — untouched.
