### PR TITLE
fix(memory): use the kernel page size, not a hardcoded 4096 (4x undercount on Apple Silicon)

### DIFF
--- a/modules/memory.sh
+++ b/modules/memory.sh
@@ -35,7 +35,7 @@ module_memory() {
         pages_wired=$(echo "$vm_output" | grep "Pages wired down" | awk '{print $4}' | tr -d '.')
 
         if [ -n "$pages_free" ] && [ -n "$pages_active" ]; then
-            local page_size=4096
+            local page_size=$(sysctl -n hw.pagesize 2>/dev/null || echo 4096)
             local total_mem=$(sysctl -n hw.memsize 2>/dev/null)
             local used_pages=$((pages_active + pages_wired))
             local used_bytes=$((used_pages * page_size))


### PR DESCRIPTION
## The bug

On macOS, `module_memory` computes used RAM as `(pages_active + pages_wired) * page_size`, with `page_size` **hardcoded to 4096** (`modules/memory.sh:38`). But `vm_stat` reports its page counts in the *kernel* page size, which is **16384 bytes on Apple Silicon** (only Intel is 4096). So on every M-series Mac the used-byte total — and the percentage and `Xg/Yg` derived from it — are undercounted by exactly 4×.

`hw.memsize` (total) is read correctly, so only the *used* side is wrong. This is the same "one sibling computes from the wrong basis" shape as #35 — the Linux branch (`/proc/meminfo`, lines 51-58) is correct. It's default-on (`MEMORY_SHOW_STATUS`/pct default true) and feeds both the displayed % and the `get_status` color.

**Verified empirically on an Apple Silicon Mac** (`uname -m` = arm64, `sysctl -n hw.pagesize` = 16384, `vm_stat` header: "page size of 16384 bytes", 36 GB):

```
active=779226 wired=182113
WRONG (4096):   10%   used=3G     <- what the statusline showed
CORRECT(16384): 40%   used=14G    <- actual usage
```

## The fix

Read the actual kernel page size — the same value `vm_stat` uses — instead of hardcoding it:

```sh
local page_size=$(sysctl -n hw.pagesize 2>/dev/null || echo 4096)
```

On Intel `hw.pagesize` is already 4096, so this is a no-op there; on Apple Silicon it becomes 16384 and the number matches reality. The `|| echo 4096` keeps the previous value as a fallback if `sysctl` is unavailable.

## Verification

- After the fix, `module_memory` on the same Mac prints `🧠 40%` (was `🧠 10%`), matching the independently-computed ground truth.
- `bash -n modules/memory.sh` clean, `shellcheck --severity=error` clean (matches the `local x=$(...)` idiom already used on the very next line for `total_mem`), `echo '{}' | bash barista.sh` exit 0.

Not unit-tested: `module_memory` calls `vm_stat`/`sysctl` directly, so a regression test would need to mock the system tools — out of scope for a one-line correctness fix (verified functionally instead, like #35).
