### PR TITLE
test(rate-limits): regression-lock _get_projection_status gating

### DIFF
--- a/tests/test_rate_limits.sh
+++ b/tests/test_rate_limits.sh
@@ -91,6 +91,30 @@ out="$(_check_backoff)"; rc=$?
 assert_eq "empty duration falls back to RATE_BACKOFF_SECONDS" "0" "$rc"
 unset RATE_BACKOFF_SECONDS
 
+# -----------------------------------------------------------------------------
+# _get_projection_status <projected>
+# The 5h/7d projection indicator (rate-limits.sh:178). Suppressed (empty) when
+# RATE_SHOW_PROJECTION is off, or when projected usage is below the warning
+# threshold -- an indicator only appears once usage projects into warning/critical
+# territory, where it delegates to get_status. Defaults: warn 80, crit 100.
+# STATUS_STYLE=ascii pins get_status to byte-clean [WARN]/[CRIT]; the per-command
+# env vars are scoped to their own $(...) subshell so they don't leak between asserts.
+# -----------------------------------------------------------------------------
+echo "=== _get_projection_status Tests ==="
+STATUS_STYLE=ascii
+DISPLAY_MODE=compact
+USE_STATUS_INDICATORS=true
+unset RATE_SHOW_PROJECTION RATE_WARNING_THRESHOLD RATE_CRITICAL_THRESHOLD
+
+assert_eq "disabled -> empty even when projected is high" ""       "$(RATE_SHOW_PROJECTION=false _get_projection_status 90)"
+assert_eq "below the default warning (80) -> empty"       ""       "$(_get_projection_status 50)"
+assert_eq "at the warning boundary (80) shows warning"    "[WARN]" "$(_get_projection_status 80)"
+assert_eq "above warning, below critical -> warning"      "[WARN]" "$(_get_projection_status 85)"
+assert_eq "at/above critical (100) -> critical"           "[CRIT]" "$(_get_projection_status 100)"
+assert_eq "custom warning threshold is honored"           "[WARN]" "$(RATE_WARNING_THRESHOLD=50 _get_projection_status 60)"
+assert_eq "below the custom warning threshold -> empty"   ""       "$(RATE_WARNING_THRESHOLD=50 _get_projection_status 40)"
+assert_eq "disabled beats a critical projection"          ""       "$(RATE_SHOW_PROJECTION=false _get_projection_status 150)"
+
 rm -f "$BACKOFF_FILE"
 rmdir "$CACHE_DIR" "$TEST_BASE" 2>/dev/null
 


### PR DESCRIPTION
## What

Regression-locks `_get_projection_status` (`modules/rate-limits.sh:178`) — the 5h/7d projection indicator, and the last untested pure helper in the module's #39-#48 lock vein. +8 asserts appended to the existing `tests/test_rate_limits.sh` (run-by-name; no new file).

The helper is a pure env-gated wrapper (its only dependency, `get_status`, is already locked). It's suppressed to empty in two independent ways — when `RATE_SHOW_PROJECTION` is off, or when projected usage is below the warning threshold — and only surfaces an indicator (delegating to `get_status`) once usage projects into warning/critical territory. The tests pin all three gates plus the threshold read:

- disabled → `""` even at a high projection (and beats a critical projection)
- below the default warning (80) → `""`; the boundary (== 80) shows warning
- warn ≤ p < crit → `[WARN]`; p ≥ crit (100) → `[CRIT]`
- a custom `RATE_WARNING_THRESHOLD` is honored (55 shows, 40 blanks)

`STATUS_STYLE=ascii DISPLAY_MODE=compact` pins `get_status` to byte-clean `[WARN]`/`[CRIT]` (no emoji-byte flakiness); the per-assert env vars are scoped to their own `$(...)` subshell so they don't leak.

## Verification

- `bash tests/test_rate_limits.sh` → **21 passed** (was 13). `bash -n` + `shellcheck --severity=error` clean. Test-only: `modules/rate-limits.sh` is byte-identical to `main`.
- **Mutation-proven non-tautological** — each mutation fails *only* its target assert(s):
  - `-lt` → `-le` on the below-warn guard → only "at the warning boundary (80) shows warning" fails.
  - default `RATE_WARNING_THRESHOLD:-80` → `:-50` → only "below the default warning (80) → empty" fails.
  - neuter the `RATE_SHOW_PROJECTION` gate (`if [...]` → `if false`) → only the two "disabled" asserts fail.
