### PR TITLE
fix: macOS CPU% drops system time + Linux running-proc count counts all procs (2 sibling-inconsistency bugs)

### DIFF
--- a/modules/cpu.sh
+++ b/modules/cpu.sh
@@ -21,7 +21,7 @@ module_cpu() {
     local cpu_usage
     if [ "$(uname)" = "Darwin" ]; then
         # macOS: use top to get CPU usage
-        cpu_usage=$(top -l 1 -n 0 2>/dev/null | grep "CPU usage" | awk '{print $3}' | tr -d '%')
+        cpu_usage=$(top -l 1 -n 0 2>/dev/null | grep "CPU usage" | awk '{u=$3; s=$5; sub(/%/,"",u); sub(/%/,"",s); print u+s}')
     else
         # Linux: use /proc/stat
         cpu_usage=$(grep 'cpu ' /proc/stat 2>/dev/null | awk '{usage=($2+$4)*100/($2+$4+$5)} END {printf "%.0f", usage}')

--- a/modules/processes.sh
+++ b/modules/processes.sh
@@ -31,7 +31,7 @@ module_processes() {
         # Linux
         if [ -d /proc ]; then
             total_procs=$(ls -d /proc/[0-9]* 2>/dev/null | wc -l)
-            running_procs=$(grep -l "^R" /proc/*/status 2>/dev/null | wc -l)
+            running_procs=$(grep -lE '^State:[[:space:]]*R' /proc/*/status 2>/dev/null | wc -l)
         else
             total_procs=$(ps aux 2>/dev/null | wc -l | tr -d ' ')
             total_procs=$((total_procs - 1))


### PR DESCRIPTION
## Summary

Byte-stable code since #49/#50 (only a docs-sync landed), so this scan re-ran the module-robustness bug sweep — the vein that's yielded #35 (temperature), #49 (memory 4× undercount), and more even on stable code. It surfaced **two more sibling-inconsistency bugs**, both the same shape as #49: a per-OS metric branch that undercounts because one platform's math diverges from the other's. Both fixed here (1 line each).

## Changes Made

- **`fix(cpu)` — macOS CPU% dropped system time.** `modules/cpu.sh`'s macOS branch read only `$3` (user %) of `top`'s `CPU usage: X% user, Y% sys, Z% idle` line, discarding `$5` (sys %). So `5% user, 12% sys` displayed as **5%** instead of ~17% — worst under kernel-heavy load. The Linux branch already computes `(user+system)/(user+system+idle)`, so the two disagreed. Now sums user+sys. **Verified live on an arm64 Mac: 2.22% → 10.73%.** (macOS is the primary platform.)
- **`fix(processes)` — Linux running-process count ≈ total.** `modules/processes.sh`'s Linux branch used `grep -l "^R" /proc/*/status`, but `^R` matches the `RssAnon:`/`RssFile:`/`RssShmem:` memory lines present in nearly every process — so `running_procs` came back ≈ the total process count, not the running count. Now matches the `State:` line's value (`grep -lE '^State:[[:space:]]*R'`). The macOS sibling (`awk '$8 ~ /R/'`) was already correct. **Verified with mock `/proc/*/status` fixtures: 3-of-3 (wrong) → 1-of-3 running (correct).**

## What Was NOT Changed

- Both `MODULE_CPU` and `PROC_SHOW_RUNNING` default off, so these are latent until enabled — but they're real correctness bugs when they are (same disposition as prior module fixes). No test lock added: both computations are impure (`top` / `/proc` reads) and aren't unit-testable without mocking the OS, so — like #49 — they're verified functionally (live host + mock fixtures), not locked.
- `memory.sh` (macOS omits compressed pages) and `disk.sh` (`df -h` column shift on wrapped device names) are cross-OS definitional / rare-wrap edges, not clean field bugs — left as-is.

## Verification
- `bash -n`: clean (both files) · `shellcheck --severity=error`: **0 errors**
- Render: `echo '{}' | bash barista.sh` → **exit 0**
- Tests: **163 / 163** (unchanged — the fixes are in impure paths the suite doesn't cover)
