### PR TITLE
fix(load,uptime): parse macOS "load averages:" (plural), not just "load average:"

### DIFF
--- a/modules/load.sh
+++ b/modules/load.sh
@@ -27,7 +27,8 @@ module_load() {
     local crit_thresh=$(safe_int "${LOAD_CRITICAL_THRESHOLD:-$((num_cpus * 2))}" "$((num_cpus * 2))")
 
     # Get load averages
-    local load_output=$(uptime 2>/dev/null | awk -F'load average:' '{print $2}')
+    # macOS prints "load averages:" (plural), Linux "load average:" — match both.
+    local load_output=$(uptime 2>/dev/null | awk -F'load averages?:' '{print $2}')
 
     if [ -z "$load_output" ]; then
         return

--- a/modules/uptime.sh
+++ b/modules/uptime.sh
@@ -39,7 +39,8 @@ module_uptime() {
 
     # Add load average if requested
     if [ "$show_load" = "true" ]; then
-        local load=$(uptime 2>/dev/null | awk -F'load average:' '{print $2}' | awk '{print $1}' | tr -d ',')
+        # macOS prints "load averages:" (plural), Linux "load average:" — match both.
+        local load=$(uptime 2>/dev/null | awk -F'load averages?:' '{print $2}' | awk '{print $1}' | tr -d ',')
         if [ -n "$load" ]; then
             result="$result [$load]"
         fi


### PR DESCRIPTION
## What

Both the Load module and the Uptime module's optional load suffix parse `uptime`'s output with `awk -F'load average:'`. That's the **singular** form. macOS `uptime` prints the **plural**:

```
15:37  up 11 days, 17:45, 4 users, load averages: 1.32 1.49 1.55
                                       ^^^^^^^^ plural
```

So on macOS — the primary platform — the field separator never matches, `$2` is empty, and:

- **Load module** (`modules/load.sh:30`): `load_output` is empty → the module hits its `[ -z ]` guard and **returns nothing**. With `MODULE_LOAD` enabled, the whole module silently disappears.
- **Uptime module** (`modules/uptime.sh:42`): the `UPTIME_SHOW_LOAD` suffix is always empty, so the `[load]` is dropped.

Linux prints `load average: 1.32, ...` (singular), so the Linux path was unaffected — a macOS-vs-Linux sibling inconsistency, same shape as the cpu/processes fixes in #51.

## Fix

Widen the separator to `load averages?:`, which matches both the plural (macOS) and singular (Linux) forms. One line in each module.

## Verification

Both modules are impure (they shell out to `uptime`), so per this repo's convention (#49/#51) there's no unit lock — verified functionally on arm64 macOS by calling the functions directly:

| | before | after |
|---|---|---|
| `module_load` | *(empty — nothing rendered)* | `📊 1.36 🟢` |
| `module_uptime` + `UPTIME_SHOW_LOAD=true` | `⏱️ 11d 17h` | `⏱️ 11d 17h [1.36]` |

The widened separator also still parses a simulated Linux line (`load average: 1.20, 1.30, 1.40` → `1.20`).

- `bash -n` clean on both files
- `shellcheck --severity=error` 0
- render smoke-test exit 0
- test suite **163/163** (unchanged — no test touched the impure parse)

## Scope note

Both modules are off by default (`MODULE_LOAD="false"`, `UPTIME_SHOW_LOAD="false"`), so this was latent — but it's a real break on the primary platform the moment either is enabled.
