### PR TITLE
fix: macOS SSID without airport + cache/token/weather/cpu hygiene

### DIFF
--- a/modules/cpu.sh
+++ b/modules/cpu.sh
@@ -17,14 +17,42 @@ module_cpu() {
     local crit_thresh="${CPU_CRITICAL_THRESHOLD:-80}"
     local show_status="${CPU_SHOW_STATUS:-true}"
 
-    # Get CPU usage (macOS specific)
+    # Get CPU usage
     local cpu_usage
     if [ "$(uname)" = "Darwin" ]; then
-        # macOS: use top to get CPU usage
+        # macOS: top sample (user + sys; #51)
         cpu_usage=$(top -l 1 -n 0 2>/dev/null | grep "CPU usage" | awk '{u=$3; s=$5; sub(/%/,"",u); sub(/%/,"",s); print u+s}')
     else
-        # Linux: use /proc/stat
-        cpu_usage=$(grep 'cpu ' /proc/stat 2>/dev/null | awk '{usage=($2+$4)*100/($2+$4+$5)} END {printf "%.0f", usage}')
+        # Linux: single-shot /proc/stat is lifetime average since boot — not
+        # "current" CPU%. Diff against a previous sample cached under barista-cache
+        # (statusline re-renders often → second+ ticks are accurate; first tick
+        # seeds the cache and returns empty so we don't show a bogus % forever).
+        local cur prev puser pnice psystem pidle cuser cnice csystem cidle
+        local duser dnice dsystem didle dtotal
+        cur=$(grep '^cpu ' /proc/stat 2>/dev/null)
+        if [ -n "$cur" ]; then
+            init_cache
+            local stat_file="${CACHE_DIR}/cpu_stat"
+            if [ -f "$stat_file" ]; then
+                prev=$(cat "$stat_file" 2>/dev/null)
+                # shellcheck disable=SC2086
+                set -- $prev
+                puser=${2:-0}; pnice=${3:-0}; psystem=${4:-0}; pidle=${5:-0}
+                # shellcheck disable=SC2086
+                set -- $cur
+                cuser=${2:-0}; cnice=${3:-0}; csystem=${4:-0}; cidle=${5:-0}
+                duser=$((cuser - puser))
+                dnice=$((cnice - pnice))
+                dsystem=$((csystem - psystem))
+                didle=$((cidle - pidle))
+                dtotal=$((duser + dnice + dsystem + didle))
+                if [ "$dtotal" -gt 0 ]; then
+                    cpu_usage=$(( (duser + dnice + dsystem) * 100 / dtotal ))
+                fi
+            fi
+            printf '%s\n' "$cur" > "$stat_file" 2>/dev/null
+            chmod 600 "$stat_file" 2>/dev/null
+        fi
     fi
 
     if [ -z "$cpu_usage" ]; then

--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -21,8 +21,15 @@ module_disk() {
     local crit_thresh="${DISK_CRITICAL_THRESHOLD:-90}"
     local show_status="${DISK_SHOW_STATUS:-true}"
 
-    # Get disk usage
-    local df_output=$(df -h "$disk_path" 2>/dev/null | tail -1)
+    # Get disk usage. Reject leading-dash paths so untrusted DISK_PATH can't
+    # inject df options (e.g. DISK_PATH=-a). Prefer end-of-options on GNU df;
+    # BSD df (macOS) ignores -- and still needs the leading-dash guard.
+    case "$disk_path" in
+        -*) return ;;
+    esac
+    local df_output
+    df_output=$(df -h -- "$disk_path" 2>/dev/null || df -h "$disk_path" 2>/dev/null)
+    df_output=$(echo "$df_output" | tail -1)
 
     if [ -z "$df_output" ]; then
         return

--- a/modules/network.sh
+++ b/modules/network.sh
@@ -41,9 +41,37 @@ module_network() {
         fi
     fi
 
-    # Get WiFi SSID (macOS)
+    # Get WiFi SSID (macOS). The legacy `airport` CLI was removed in Sonoma+;
+    # prefer networksetup / ipconfig getsummary, fall back to airport if present.
+    # Capture the full SSID (spaces allowed) — never awk $2 only.
     if [ "$show_ssid" = "true" ] && [ "$(uname)" = "Darwin" ]; then
-        local ssid=$(/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -I 2>/dev/null | grep ' SSID' | awk '{print $2}')
+        local ssid="" wifi_dev line airport
+        wifi_dev=$(networksetup -listallhardwareports 2>/dev/null | awk '/Wi-Fi|AirPort/{getline; print $2; exit}')
+        wifi_dev="${wifi_dev:-en0}"
+
+        line=$(networksetup -getairportnetwork "$wifi_dev" 2>/dev/null)
+        case "$line" in
+            "Current Wi-Fi Network: "*)
+                ssid="${line#Current Wi-Fi Network: }"
+                ;;
+        esac
+
+        if [ -z "$ssid" ]; then
+            ssid=$(ipconfig getsummary "$wifi_dev" 2>/dev/null | sed -n 's/^  SSID : //p' | head -1)
+        fi
+
+        if [ -z "$ssid" ]; then
+            for airport in \
+                /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport \
+                /System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport; do
+                if [ -x "$airport" ]; then
+                    # Full field after ": " — multi-word SSIDs
+                    ssid=$("$airport" -I 2>/dev/null | sed -n 's/^ *SSID: //p' | head -1)
+                    break
+                fi
+            done
+        fi
+
         if [ -n "$ssid" ]; then
             if [ -n "$parts" ]; then
                 parts="$parts ($ssid)"

--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -124,6 +124,10 @@ _get_claude_usage() {
     local tmp_headers="$CACHE_DIR/rate_limits_headers"
     local tmp_curlcfg="$CACHE_DIR/rate_limits_curlcfg"
     init_cache
+    # Clean curlcfg (Bearer token) + response temps even if curl is killed/timeout.
+    # Bash 3.2: EXIT trap covers normal return and signals that terminate the shell.
+    # shellcheck disable=SC2064
+    trap 'rm -f "$tmp_curlcfg" "$tmp_file" "$tmp_headers" 2>/dev/null' EXIT
     printf 'header = "Authorization: Bearer %s"\n' "$token" > "$tmp_curlcfg"
     chmod 600 "$tmp_curlcfg" 2>/dev/null
     # On Git Bash / MSYS, some mingw curl builds (notably 8.8 shipped with
@@ -147,12 +151,14 @@ _get_claude_usage() {
         "https://api.anthropic.com/api/oauth/usage" \
         -H "anthropic-beta: oauth-2025-04-20" \
         -H "Accept: application/json" 2>/dev/null)
+    # Wipe token file immediately after curl (trap is the safety net)
     rm -f "$tmp_curlcfg" 2>/dev/null
 
     case "$http_code" in
         200)
             cat "$tmp_file" 2>/dev/null
             rm -f "$tmp_file" "$tmp_headers" 2>/dev/null
+            trap - EXIT
             return 0
             ;;
         429)
@@ -164,11 +170,13 @@ _get_claude_usage() {
             init_cache
             echo "$backoff_duration" > "$backoff_file" 2>/dev/null
             rm -f "$tmp_file" "$tmp_headers" 2>/dev/null
+            trap - EXIT
             return 1
             ;;
         *)
             log_debug "rate-limits: API returned HTTP $http_code"
             rm -f "$tmp_file" "$tmp_headers" 2>/dev/null
+            trap - EXIT
             return 1
             ;;
     esac

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -46,11 +46,13 @@ CACHE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/barista-cache"
 init_cache() {
     if [ ! -d "$CACHE_DIR" ]; then
         mkdir -p "$CACHE_DIR" 2>/dev/null
-        # Restrict to the owner so the cache dir can't be world-readable under a
-        # permissive umask — the cache key names (weather, wan_ip, update_check…)
-        # would otherwise leak config state to other local users. Cache files are
-        # already chmod 600 individually; this hardens the directory uniformly for
-        # every cache client (matches network.sh/weather.sh).
+    fi
+    # Always re-assert owner-only mode. #34 chmod'd only on create, so a
+    # pre-existing world-readable ~/.claude/barista-cache (older install or
+    # permissive umask) was never repaired. Cache key names (weather, wan_ip,
+    # rate_limits_curlcfg, update_check…) must not leak to other local users.
+    # Matches network.sh / weather.sh which re-chmod every call.
+    if [ -d "$CACHE_DIR" ]; then
         chmod 700 "$CACHE_DIR" 2>/dev/null
     fi
 }

--- a/modules/weather.sh
+++ b/modules/weather.sh
@@ -42,9 +42,12 @@ module_weather() {
 
     # Fetch fresh data if needed
     if [ -z "$weather_data" ]; then
-        # Sanitize location: reject shell metacharacters and URL-unsafe sequences
+        # Sanitize location: reject shell metacharacters AND URL query hijacks.
+        # Untrusted project .barista.conf can set WEATHER_LOCATION; a value like
+        # "x?format=@v" or "x#frag" would rewrite the wttr.in query string.
+        # Also reject whitespace / control chars (path segment must stay simple).
         case "$location" in
-            *\`*|*\$\(*|*\;*|*\|*|*\&*|*\>*|*\<*|*\'*|*\"*|*\\*)
+            *\`*|*\$\(*|*\;*|*\|*|*\&*|*\>*|*\<*|*\'*|*\"*|*\\*|*'?'*|*'#'*|*' '*|*[[:cntrl:]]*)
                 log_debug "weather: rejected unsafe WEATHER_LOCATION value"
                 return
                 ;;


### PR DESCRIPTION
## Summary

Live platform re-sweep (post-#52) found several default-off / optional-path bugs and small security hygiene gaps. All changes are scan-sized, Bash 3.2-safe, no CI.

### Fixes

| Area | Change |
|------|--------|
| **network SSID** | `airport` CLI is gone on Sonoma+. Prefer `networksetup -getairportnetwork` + `ipconfig getsummary` (full multi-word SSID); keep airport as last resort |
| **init_cache** | Always `chmod 700` (not only on create) so older world-readable cache dirs get repaired |
| **rate-limits** | `trap EXIT` cleanup for Bearer token curlcfg + response temps if curl is killed mid-request |
| **weather** | Reject `?` `#` whitespace/control in `WEATHER_LOCATION` (untrusted conf could rewrite wttr query) |
| **disk** | Reject leading-dash `DISK_PATH`; use `df --` when available |
| **cpu (Linux)** | Diff cached `/proc/stat` samples instead of lifetime average since boot |

### Filed separately

- #53 — brightness AppleScript/ioreg fallbacks dead on modern macOS (follow-up)
- #26 — git TTL-cache scoping note re-posted (awaiting author TTL/mtime answers)

### Verification

- `bash -n` 35/35
- `shellcheck --severity=error` 0
- tests 163/163 (sandbox/utils/cache/rate_limits/update/uptime/project)
- `echo '{}' \| bash barista.sh` exit 0
- Live: SSID path returns LAN + SSID on arm64 macOS; `init_cache` 755→700; weather `x?format=@v` rejected; `DISK_PATH=-a` no-op

### Not in this PR

Feature issues #23/#24/#26 remain author-gated. Brightness #53 deferred to keep scope tight.
