### PR TITLE
fix(brightness,cache,oauth): modern macOS backlight + file/token hygiene

### DIFF
--- a/barista.conf
+++ b/barista.conf
@@ -590,7 +590,7 @@ TEMP_SHOW_STATUS="true"
 # =============================================================================
 # BRIGHTNESS MODULE
 # =============================================================================
-# Note: May require 'brightness' CLI tool on macOS (brew install brightness)
+# Note: macOS uses IODisplayParameters via ioreg (no brew needed); optional brew brightness
 
 # Icon displayed before brightness
 BRIGHTNESS_ICON="☀️"

--- a/modules/brightness.sh
+++ b/modules/brightness.sh
@@ -9,11 +9,13 @@
 #   BRIGHTNESS_BAR_WIDTH    - Width of progress bar (default: 5)
 # =============================================================================
 
-# Note: Requires brightness command (brew install brightness) or
-# uses AppleScript fallback on macOS
+# macOS: prefer IODisplayParameters via ioreg (works without third-party tools).
+# Optional accelerator: brew install brightness. Legacy appearance-preferences
+# AppleScript and fixed 0–1024 AppleBacklightDisplay scale are dead on modern macOS.
 
 module_brightness() {
-    local icon=$(get_icon "${BRIGHTNESS_ICON:-☀️}" "BRT:")
+    local icon
+    icon=$(get_icon "${BRIGHTNESS_ICON:-☀️}" "BRT:")
     local show_pct="${BRIGHTNESS_SHOW_PERCENT:-true}"
     local show_bar="${BRIGHTNESS_SHOW_BAR:-false}"
     local bar_width="${BRIGHTNESS_BAR_WIDTH:-5}"
@@ -21,7 +23,7 @@ module_brightness() {
     local brightness=""
 
     if [ "$(uname)" = "Darwin" ]; then
-        # Try brightness command first
+        # Prefer brew brightness CLI when present (fast, direct)
         if command -v brightness >/dev/null 2>&1; then
             brightness=$(brightness -l 2>/dev/null | grep -o 'brightness [0-9.]*' | awk '{print $2}' | head -1)
             if [ -n "$brightness" ]; then
@@ -29,20 +31,31 @@ module_brightness() {
             fi
         fi
 
-        # Fallback to AppleScript
+        # Primary fallback: IODisplayParameters "brightness"={min,max,value}
+        # Live shape (Apple Silicon / modern macOS): max=65536, not 0–1024.
         if [ -z "$brightness" ]; then
-            brightness=$(osascript -e 'tell application "System Events" to tell appearance preferences to get brightness' 2>/dev/null)
-            if [ -n "$brightness" ]; then
-                brightness=$(echo "scale=0; $brightness * 100" | bc -l 2>/dev/null || echo "")
+            local dict max val
+            # Isolate the brightness dict (not BrightnessMilliNits / rawBrightness)
+            dict=$(ioreg -l 2>/dev/null | grep -o '"brightness"={"min"=[0-9]*,"max"=[0-9]*,"value"=[0-9]*}' | head -1)
+            if [ -n "$dict" ]; then
+                max=$(echo "$dict" | grep -o '"max"=[0-9]*' | cut -d= -f2)
+                val=$(echo "$dict" | grep -o '"value"=[0-9]*' | cut -d= -f2)
+                if [ -n "$max" ] && [ "$max" -gt 0 ] && [ -n "$val" ]; then
+                    brightness=$((val * 100 / max))
+                fi
             fi
         fi
 
-        # Another fallback using ioreg
+        # Last resort: rawBrightness with its own max (often 2047 on Apple Silicon)
         if [ -z "$brightness" ]; then
-            local raw=$(ioreg -c AppleBacklightDisplay 2>/dev/null | grep -i "brightness" | head -1 | grep -o '"brightness"=[0-9]*' | cut -d= -f2)
-            if [ -n "$raw" ]; then
-                # This is typically 0-1024, convert to percentage
-                brightness=$((raw * 100 / 1024))
+            local dict max val
+            dict=$(ioreg -l 2>/dev/null | grep -o '"rawBrightness"={"min"=[0-9]*,"max"=[0-9]*,"value"=[0-9]*}' | head -1)
+            if [ -n "$dict" ]; then
+                max=$(echo "$dict" | grep -o '"max"=[0-9]*' | cut -d= -f2)
+                val=$(echo "$dict" | grep -o '"value"=[0-9]*' | cut -d= -f2)
+                if [ -n "$max" ] && [ "$max" -gt 0 ] && [ -n "$val" ]; then
+                    brightness=$((val * 100 / max))
+                fi
             fi
         fi
     else
@@ -65,7 +78,8 @@ module_brightness() {
         return
     fi
 
-    local brightness_int=$(printf "%.0f" "$brightness" 2>/dev/null || echo "0")
+    local brightness_int
+    brightness_int=$(printf "%.0f" "$brightness" 2>/dev/null || echo "0")
 
     local result="$icon"
 

--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -319,12 +319,15 @@ module_rate_limits() {
 
         # Record the data point
         echo "$now,$five_hour,$seven_day,$five_hour_reset,$seven_day_reset" >> "$history_file" 2>/dev/null
+        # Not secrets, but keep owner-only like cache/token temps (defense-in-depth)
+        chmod 600 "$history_file" 2>/dev/null
 
         # Routine cleanup - keep last 100 entries within 24 hours
         if [ -f "$history_file" ]; then
             local cutoff=$((now - 86400))
             tail -100 "$history_file" | awk -F',' -v cutoff="$cutoff" '$1 >= cutoff' > "${history_file}.tmp" 2>/dev/null && \
                 mv "${history_file}.tmp" "$history_file" 2>/dev/null
+            chmod 600 "$history_file" 2>/dev/null
         fi
     fi
 

--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -146,7 +146,10 @@ _get_claude_usage() {
     esac
 
     local http_code
-    http_code=$("$curl_bin" -s --max-time 5 -o "$tmp_file" -D "$tmp_headers" -w "%{http_code}" \
+    # --proto =https + --max-redirs 3: match weather/update; block HTTP redirect
+    # that could re-expose the Bearer token from curlcfg on a non-TLS hop.
+    http_code=$("$curl_bin" -s --max-time 5 --proto =https --max-redirs 3 \
+        -o "$tmp_file" -D "$tmp_headers" -w "%{http_code}" \
         --config "$tmp_curlcfg" \
         "https://api.anthropic.com/api/oauth/usage" \
         -H "anthropic-beta: oauth-2025-04-20" \

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -112,6 +112,8 @@ cache_set() {
 
     local cache_file="$CACHE_DIR/${key}"
     echo "$value" > "$cache_file" 2>/dev/null
+    # Defense-in-depth if dir 700 fails (odd FS/umask); matches wan_ip/token files.
+    chmod 600 "$cache_file" 2>/dev/null
 }
 
 # Clear specific cache key or all cache


### PR DESCRIPTION
## Summary

Completes the post-#54 platform hygiene pass: brightness on modern macOS without `brew brightness` (#53), OAuth curl HTTPS pinning, and cache/history file modes.

## Changes Made

- **modules/brightness.sh** — Replace dead AppleScript appearance-preferences path and fixed 0–1024 AppleBacklightDisplay scale with `IODisplayParameters` `"brightness"={min,max,value}` (live max=65536) and `rawBrightness` last resort. Keep brew `brightness` as optional accelerator. Live-verified: empty → `☀️ 50%` on Apple Silicon.
- **modules/rate-limits.sh** — OAuth usage fetch uses `--proto =https --max-redirs 3` (same as weather/update) so a redirect cannot re-expose Bearer curlcfg on a non-TLS hop. `chmod 600` on `.usage_history` after append/truncate.
- **modules/utils.sh** — `cache_set` always `chmod 600` the written file (defense-in-depth if dir 700 fails).
- **barista.conf** — Brightness module note no longer claims brew is required.

## What Was NOT Changed

- #23 Homebrew/npx install — feature-sized, author product call
- #24 `barista config` TUI — feature-sized UX
- #26 git TTL cache — vertical-slice eligible but still blocked on TTL default (2 vs 3s) + mtime invalidation author answers
- Module-source world-writable check (security note only; install-path trust model)
- Below-error shellcheck findings (author policy)
- No CI workflows (fleet policy)

## Verification

- Build/syntax: `bash -n` all `.sh` PASS
- ShellCheck: `--severity=error` 0 errors
- Tests: 163/163 (sandbox 4 + utils 94 + cache 14 + rate_limits 21 + update 8 + uptime 9 + project 13)
- Render: `echo '{}' | bash barista.sh` exit 0
- Live: `ioreg` brightness dict max=65536; `module_brightness` → 50%; uptime `load averages?:` parse still OK

Fixes #53
