### PR TITLE
fix(git): TTL-cache branch and porcelain status (#26)

### DIFF
--- a/barista.conf
+++ b/barista.conf
@@ -177,6 +177,10 @@ GIT_FILE_ICON="📝"
 # Compact mode: shows just branch and symbols, no file count
 GIT_COMPACT="false"
 
+# TTL (seconds) for caching git subprocess output across statusline re-renders.
+# Busts early when .git/HEAD or .git/index mtime is newer. 0 = disable. (#26)
+GIT_CACHE_TTL="2"
+
 # =============================================================================
 # PROJECT MODULE
 # =============================================================================

--- a/modules/git.sh
+++ b/modules/git.sh
@@ -6,25 +6,52 @@
 #   GIT_ICON              - Icon before branch name (default: 🌿)
 #   GIT_SHOW_BRANCH       - Show branch name (default: true)
 #   GIT_SHOW_STATUS       - Show status symbols (default: true)
-#   GIT_SHOW_FILE_COUNT   - Show modified file count (default: true)
-#   GIT_SYMBOL_MODIFIED   - Symbol for modified files (default: ●)
+#   GIT_SHOW_FILE_COUNT    - Show modified file count (default: true)
+#   GIT_SYMBOL_MODIFIED    - Symbol for modified files (default: ●)
 #   GIT_SYMBOL_UNTRACKED  - Symbol for untracked files (default: +)
-#   GIT_SYMBOL_STAGED     - Symbol for staged files (default: ✓)
-#   GIT_FILE_ICON         - Icon before file count (default: 📝)
-#   GIT_COMPACT           - Compact mode (default: false)
+#   GIT_SYMBOL_STAGED      - Symbol for staged files (default: ✓)
+#   GIT_FILE_ICON          - Icon before file count (default: 📝)
+#   GIT_COMPACT            - Compact mode (default: false)
+#   GIT_CACHE_TTL          - Seconds to TTL-cache git subprocess output (default: 2).
+#                           Set 0 to disable. Cache busts early if .git/HEAD or
+#                           .git/index is newer than the cache entry (issue #26).
 # =============================================================================
+
+# Hash a path into a cache-key-safe token (no / or ..). Prefer sha256, fall back.
+_git_cache_key_for_dir() {
+    local path="$1"
+    local h=""
+    if command -v shasum >/dev/null 2>&1; then
+        h=$(printf '%s' "$path" | shasum -a 256 2>/dev/null | cut -c1-16)
+    elif command -v sha256sum >/dev/null 2>&1; then
+        h=$(printf '%s' "$path" | sha256sum 2>/dev/null | cut -c1-16)
+    elif command -v md5 >/dev/null 2>&1; then
+        h=$(printf '%s' "$path" | md5 -q 2>/dev/null | cut -c1-16)
+    elif command -v md5sum >/dev/null 2>&1; then
+        h=$(printf '%s' "$path" | md5sum 2>/dev/null | cut -c1-16)
+    else
+        # Portable last resort: cksum + length (collision-resistant enough for local TTL)
+        h=$(printf '%s' "$path" | cksum 2>/dev/null | tr -d ' ')
+    fi
+    [ -n "$h" ] || h="default"
+    echo "git_${h}"
+}
 
 module_git() {
     local current_dir="$1"
-    local icon=$(get_icon "${GIT_ICON:-🌿}" "GIT:")
+    local icon
+    icon=$(get_icon "${GIT_ICON:-🌿}" "GIT:")
     local show_branch="${GIT_SHOW_BRANCH:-true}"
     local show_status="${GIT_SHOW_STATUS:-true}"
     local show_count="${GIT_SHOW_FILE_COUNT:-true}"
     local sym_modified="${GIT_SYMBOL_MODIFIED:-●}"
     local sym_untracked="${GIT_SYMBOL_UNTRACKED:-+}"
     local sym_staged="${GIT_SYMBOL_STAGED:-✓}"
-    local file_icon=$(get_icon "${GIT_FILE_ICON:-📝}" "")
+    local file_icon
+    file_icon=$(get_icon "${GIT_FILE_ICON:-📝}" "")
     local compact="${GIT_COMPACT:-false}"
+    # TTL default 2s; 0 disables (scoping note #26 Phase 1)
+    local git_ttl="${GIT_CACHE_TTL:-2}"
 
     # Safety check: ensure directory exists and is accessible
     if [ -z "$current_dir" ] || [ ! -d "$current_dir" ]; then
@@ -36,22 +63,89 @@ module_git() {
     cd "$current_dir" 2>/dev/null || return
 
     # Quick check: are we in a git repo?
-    if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    local git_dir
+    git_dir=$(git rev-parse --git-dir 2>/dev/null) || {
         cd "$orig_dir" 2>/dev/null || return
         return
+    }
+
+    # Resolve absolute git dir for stable cache keys + mtime targets
+    local abs_git_dir
+    if [ -d "$git_dir" ]; then
+        abs_git_dir=$(cd "$git_dir" 2>/dev/null && pwd -P)
+    fi
+    [ -n "$abs_git_dir" ] || abs_git_dir="$git_dir"
+
+    local head_file="$abs_git_dir/HEAD"
+    local index_file="$abs_git_dir/index"
+    local cache_key=""
+    local use_cache=false
+    local git_branch=""
+    local git_porcelain=""
+    local from_cache=false
+
+    # Numeric TTL > 0 enables cache (non-numeric → treat as disabled)
+    case "$git_ttl" in
+        ''|*[!0-9]*) git_ttl=0 ;;
+    esac
+    if [ "$git_ttl" -gt 0 ] 2>/dev/null; then
+        use_cache=true
+        cache_key=$(_git_cache_key_for_dir "$abs_git_dir")
     fi
 
-    # Get branch name (handles detached HEAD)
-    local git_branch
-    git_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
-    if [ -z "$git_branch" ]; then
-        # Detached HEAD - show short SHA
-        git_branch=$(git rev-parse --short HEAD 2>/dev/null)
-        if [ -z "$git_branch" ]; then
-            cd "$orig_dir" 2>/dev/null || return
-            return
+    if [ "$use_cache" = "true" ]; then
+        local cached=""
+        cached=$(cache_get "$cache_key" "$git_ttl" 2>/dev/null) || cached=""
+        if [ -n "$cached" ]; then
+            # Bust if HEAD or index changed after the cache write
+            local cache_file="$CACHE_DIR/${cache_key}"
+            local cache_mtime head_mtime index_mtime
+            cache_mtime=$(_file_mtime "$cache_file")
+            head_mtime=$(_file_mtime "$head_file")
+            index_mtime=$(_file_mtime "$index_file")
+            if [ "$head_mtime" -gt "$cache_mtime" ] 2>/dev/null \
+                || [ "$index_mtime" -gt "$cache_mtime" ] 2>/dev/null; then
+                cached=""
+            fi
         fi
-        git_branch="($git_branch)"  # Indicate detached state
+        if [ -n "$cached" ]; then
+            # Format: first line = branch; remainder after sentinel = porcelain
+            git_branch=$(printf '%s\n' "$cached" | head -n 1)
+            git_porcelain=$(printf '%s\n' "$cached" | sed '1,/^---BARISTA_GIT---$/d')
+            # Empty branch line means corrupt entry — recompute
+            if [ -n "$git_branch" ]; then
+                from_cache=true
+            else
+                git_porcelain=""
+            fi
+        fi
+    fi
+
+    if [ "$from_cache" != "true" ]; then
+        # Get branch name (handles detached HEAD)
+        git_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+        if [ -z "$git_branch" ]; then
+            # Detached HEAD - show short SHA
+            git_branch=$(git rev-parse --short HEAD 2>/dev/null)
+            if [ -z "$git_branch" ]; then
+                cd "$orig_dir" 2>/dev/null || return
+                return
+            fi
+            git_branch="($git_branch)"  # Indicate detached state
+        fi
+
+        # PERFORMANCE: single git status --porcelain; MEMORY: cap monorepo output
+        if [ "$show_status" = "true" ] || [ "$show_count" = "true" ]; then
+            local max_lines=500
+            git_porcelain=$(git status --porcelain 2>/dev/null | head -n "$max_lines")
+        fi
+
+        if [ "$use_cache" = "true" ]; then
+            # Store branch + porcelain for next render within TTL
+            cache_set "$cache_key" "${git_branch}
+---BARISTA_GIT---
+${git_porcelain}"
+        fi
     fi
 
     local result="$icon"
@@ -65,13 +159,7 @@ module_git() {
     # This replaces 4 separate git commands with 1
     # MEMORY OPTIMIZATION: Limit output to prevent OOM in large monorepos
     if [ "$show_status" = "true" ] || [ "$show_count" = "true" ]; then
-        local git_porcelain
         local max_lines=500  # Cap to prevent memory issues in monorepos
-        local line_count=0
-        local hit_limit=false
-
-        # Use head to limit output and prevent loading megabytes of data
-        git_porcelain=$(git status --porcelain 2>/dev/null | head -n "$max_lines")
 
         if [ "$show_status" = "true" ]; then
             local has_modified=false
@@ -128,8 +216,14 @@ module_git() {
                 modified_count=$(echo "$git_porcelain" | grep -c '^' 2>/dev/null || echo "0")
                 # If we hit the limit, get actual count efficiently with wc -l
                 if [ "$modified_count" -ge "$max_lines" ]; then
-                    modified_count=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
-                    count_display="${modified_count}"
+                    # Only re-run full status when not serving from short TTL cache
+                    # (cached path already capped; exact monorepo count is best-effort)
+                    if [ "$from_cache" = "true" ]; then
+                        count_display="${modified_count}+"
+                    else
+                        modified_count=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+                        count_display="${modified_count}"
+                    fi
                 else
                     count_display="${modified_count}"
                 fi

--- a/tests/test_git_cache.sh
+++ b/tests/test_git_cache.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# ABOUTME: Regression-lock for modules/git.sh TTL cache helpers (#26)
+# ABOUTME: Run with: bash tests/test_git_cache.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected: '$expected'"
+        echo "    actual:   '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_match() {
+    local desc="$1" pattern="$2" actual="$3"
+    if printf '%s' "$actual" | grep -Eq "$pattern"; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    pattern: '$pattern'"
+        echo "    actual:  '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/modules/utils.sh"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/modules/git.sh"
+
+TEST_BASE="$(mktemp -d "${TMPDIR:-/tmp}/barista-git-cache-test.XXXXXX")"
+CACHE_DIR="$TEST_BASE/cache"
+init_cache
+
+# Key helper: stable, no path separators
+k1=$(_git_cache_key_for_dir "/tmp/example/repo/.git")
+k2=$(_git_cache_key_for_dir "/tmp/example/repo/.git")
+k3=$(_git_cache_key_for_dir "/tmp/other/repo/.git")
+assert_eq "cache key is stable for same path" "$k1" "$k2"
+assert_match "cache key has git_ prefix" '^git_' "$k1"
+assert_eq "cache key has no slash" "0" "$(printf '%s' "$k1" | grep -c / || true)"
+assert_eq "different paths get different keys" "1" "$([ "$k1" != "$k3" ] && echo 1 || echo 0)"
+
+# Round-trip branch+porcelain payload through cache_get/set (same format as module_git)
+payload="main
+---BARISTA_GIT---
+ M modules/git.sh
+?? untracked.txt"
+cache_set "$k1" "$payload"
+got=$(cache_get "$k1" 60)
+branch=$(printf '%s\n' "$got" | head -n 1)
+porcelain=$(printf '%s\n' "$got" | sed '1,/^---BARISTA_GIT---$/d')
+assert_eq "cached branch round-trips" "main" "$branch"
+assert_match "cached porcelain includes modified line" ' M modules/git.sh' "$porcelain"
+assert_match "cached porcelain includes untracked line" '\?\? untracked.txt' "$porcelain"
+
+# TTL=0 path: module still runs when pointed at this worktree
+export GIT_CACHE_TTL=0
+export USE_ICONS=false
+export GIT_SHOW_STATUS=true
+export GIT_SHOW_FILE_COUNT=false
+export GIT_SHOW_BRANCH=true
+out=$(module_git "$SCRIPT_DIR" 2>/dev/null || true)
+assert_match "module_git renders with TTL disabled" 'GIT:|🌿' "$out"
+# Prefer GIT: fallback since USE_ICONS=false
+assert_match "module_git shows branch or git label" '.' "$out"
+
+rm -rf "$TEST_BASE"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
Implements Phase 1 of #26: TTL-cache git subprocess output (branch + porcelain) so Claude Code statusline re-renders skip redundant `git` spawns.

- `GIT_CACHE_TTL` (default `2`, `0` = off) via existing `cache_get`/`cache_set`
- Early bust when `.git/HEAD` or `.git/index` mtime is newer than the cache file
- Cache key is a path hash (`git_<16hex>`) so `utils.sh` path-traversal guards stay valid
- `tests/test_git_cache.sh` (9 cases); full suite **172** pass
- Documented in `barista.conf`

Fixes #26

## Verification
- `bash -n` modules/git.sh
- `shellcheck -S error` clean on touched scripts
- All `tests/test_*.sh`: 172 passed, 0 failed
- Smoke render ×2 exit 0 (cache warm path)

## Not in this PR
- #24 barista config TUI (feature)
- #23 Homebrew/npx install (author packaging decision)