### PR TITLE
Harden update and credential checks

### DIFF
--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -27,14 +27,37 @@
 #   1. ~/.claude/.credentials.json — used on Windows and some Linux setups
 #   2. macOS Keychain via `security` — used on macOS
 # Handles both plain JSON and hex-encoded formats (macOS 15+ / recent Claude Code)
+_credentials_file_is_private() {
+    local file="$1"
+    local mode=""
+
+    # Use the platform stat directly on macOS so a Homebrew GNU stat earlier in
+    # PATH cannot reinterpret BSD flags. If mode discovery fails, fail closed.
+    if [[ "${OSTYPE:-}" == darwin* ]]; then
+        mode=$(/usr/bin/stat -f %Lp "$file" 2>/dev/null) || return 1
+    else
+        mode=$(stat -c %a "$file" 2>/dev/null) || return 1
+    fi
+
+    case "$mode" in
+        ""|*[!0-7]*) return 1 ;;
+        *00) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 _get_claude_token() {
     local creds_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json"
     if [ -f "$creds_file" ]; then
-        local file_token
-        file_token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
-        if [ -n "$file_token" ]; then
-            echo "$file_token"
-            return
+        if _credentials_file_is_private "$creds_file"; then
+            local file_token
+            file_token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+            if [ -n "$file_token" ]; then
+                echo "$file_token"
+                return
+            fi
+        else
+            log_debug "rate-limits: refusing credentials file with group or other permissions"
         fi
     fi
 

--- a/modules/update.sh
+++ b/modules/update.sh
@@ -82,20 +82,30 @@ _check_barista_update() {
     fi
 }
 
+# Return the leading numeric portion of a semantic-version component.
+# Release tags can include suffixes such as "0-rc1"; keeping only the leading
+# digits makes the numeric comparison safe without trying to order prereleases.
+_version_numeric_component() {
+    local value="${1:-}"
+    value="${value%%[!0-9]*}"
+    printf '%s\n' "${value:-0}"
+}
+
 # Compare two semver strings: returns 0 if $1 > $2
 _version_gt() {
     local v1="$1" v2="$2"
-    # Split on dots and compare numerically
+    # Split on dots and compare the numeric prefix of each component. Bash's
+    # arithmetic parser rejects values such as "0-rc1", so sanitize first.
     local v1_major v1_minor v1_patch v2_major v2_minor v2_patch
-    v1_major=$(echo "$v1" | cut -d. -f1)
-    v1_minor=$(echo "$v1" | cut -d. -f2)
-    v1_patch=$(echo "$v1" | cut -d. -f3)
-    v2_major=$(echo "$v2" | cut -d. -f1)
-    v2_minor=$(echo "$v2" | cut -d. -f2)
-    v2_patch=$(echo "$v2" | cut -d. -f3)
+    IFS=. read -r v1_major v1_minor v1_patch _ <<< "$v1"
+    IFS=. read -r v2_major v2_minor v2_patch _ <<< "$v2"
 
-    v1_major=$((v1_major + 0)); v1_minor=$((v1_minor + 0)); v1_patch=$((v1_patch + 0))
-    v2_major=$((v2_major + 0)); v2_minor=$((v2_minor + 0)); v2_patch=$((v2_patch + 0))
+    v1_major=$(_version_numeric_component "$v1_major")
+    v1_minor=$(_version_numeric_component "$v1_minor")
+    v1_patch=$(_version_numeric_component "$v1_patch")
+    v2_major=$(_version_numeric_component "$v2_major")
+    v2_minor=$(_version_numeric_component "$v2_minor")
+    v2_patch=$(_version_numeric_component "$v2_patch")
 
     if [ "$v1_major" -gt "$v2_major" ]; then return 0; fi
     if [ "$v1_major" -lt "$v2_major" ]; then return 1; fi

--- a/tests/test_rate_limits.sh
+++ b/tests/test_rate_limits.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # ABOUTME: Tests for modules/rate-limits.sh -- _parse_reset_epoch (the #38 resets_at
 # ABOUTME: ISO-8601 -> epoch parser that works on BSD/macOS and GNU/Linux date) and
-# ABOUTME: _check_backoff (the post-429 cooldown-state file reader).
+# ABOUTME: credential-file permission enforcement and _check_backoff (the post-429
+# ABOUTME: cooldown-state file reader).
 # ABOUTME: Run with: bash tests/test_rate_limits.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -44,6 +45,38 @@ assert_eq "unparseable input falls back to 0"          "0"          "$(_parse_re
 # Load utils.sh too -- _check_backoff needs _file_mtime + CACHE_DIR from it.
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/modules/utils.sh"
+
+# -----------------------------------------------------------------------------
+# _get_claude_token / _credentials_file_is_private
+# A plaintext OAuth token may only be read from an owner-only credentials file.
+# Stub `security` so a rejected file can never fall through to the developer's
+# real macOS Keychain while this test runs.
+# -----------------------------------------------------------------------------
+echo "=== Credential Permission Tests ==="
+TOKEN_CONFIG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/barista-token-test.XXXXXX")"
+TOKEN_BIN="$TOKEN_CONFIG_DIR/bin"
+mkdir -p "$TOKEN_BIN"
+printf '#!/bin/sh\nexit 1\n' > "$TOKEN_BIN/security"
+chmod 700 "$TOKEN_BIN/security"
+printf '{"claudeAiOauth":{"accessToken":"permission-test-token"}}\n' > "$TOKEN_CONFIG_DIR/.credentials.json"
+
+chmod 600 "$TOKEN_CONFIG_DIR/.credentials.json"
+assert_eq "owner-only credentials file is accepted" \
+    "permission-test-token" \
+    "$(CLAUDE_CONFIG_DIR="$TOKEN_CONFIG_DIR" PATH="$TOKEN_BIN:$PATH" _get_claude_token)"
+
+chmod 640 "$TOKEN_CONFIG_DIR/.credentials.json"
+assert_eq "group-readable credentials file is rejected" \
+    "" \
+    "$(CLAUDE_CONFIG_DIR="$TOKEN_CONFIG_DIR" PATH="$TOKEN_BIN:$PATH" _get_claude_token)"
+
+chmod 604 "$TOKEN_CONFIG_DIR/.credentials.json"
+assert_eq "world-readable credentials file is rejected" \
+    "" \
+    "$(CLAUDE_CONFIG_DIR="$TOKEN_CONFIG_DIR" PATH="$TOKEN_BIN:$PATH" _get_claude_token)"
+
+rm -f "$TOKEN_CONFIG_DIR/.credentials.json" "$TOKEN_BIN/security"
+rmdir "$TOKEN_BIN" "$TOKEN_CONFIG_DIR" 2>/dev/null
 
 # Sandbox CACHE_DIR so the suite never touches the real ~/.claude/barista-cache.
 TEST_BASE="$(mktemp -d "${TMPDIR:-/tmp}/barista-backoff-test.XXXXXX")"

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -22,7 +22,7 @@ assert_eq() {
     fi
 }
 
-# Load the module under test. _version_gt is pure (cut + arithmetic, no I/O).
+# Load the module under test. _version_gt is pure and performs no external I/O.
 . "$SCRIPT_DIR/modules/update.sh"
 
 # _version_gt <v1> <v2> -> rc 0 when v1 > v2, rc 1 otherwise.
@@ -44,6 +44,12 @@ assert_gt "patch numeric: 1.0.10 > 1.0.9"        "1.0.10" "1.0.9"  "0"
 assert_gt "patch: 1.7.0 is not > 1.7.1"          "1.7.0"  "1.7.1"  "1"
 # Equal versions are NOT greater (so the update prompt does not fire on an equal remote)
 assert_gt "equal is not greater: 1.7.0 vs 1.7.0" "1.7.0"  "1.7.0"  "1"
+# Prerelease/build suffixes must never reach Bash's arithmetic parser. The
+# comparator intentionally compares only the numeric major/minor/patch tuple.
+assert_gt "prerelease patch compares safely above older release" "1.8.0-rc1" "1.7.9" "0"
+assert_gt "prerelease suffix is equal to its numeric release"     "1.8.0-rc1" "1.8.0" "1"
+assert_gt "build metadata does not change numeric precedence"     "2.1.3+45"  "2.1.3" "1"
+assert_gt "nonnumeric patch is treated as zero"                   "1.8.x"     "1.7.9" "0"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

- sanitize semantic-version components before numeric comparison so prerelease and build suffixes cannot trigger Bash arithmetic errors
- refuse plaintext Claude credential files with any group or other permission bits, failing closed when mode inspection fails
- add Bash 3.2 regressions for prerelease tags and owner-only credential-file enforcement

## Validation

- all 190 shell tests pass
- Bash syntax passes for changed scripts and tests
- ShellCheck reports only two pre-existing SC2181 findings in untouched rate-limit paths; no new finding is introduced
- diff check passes

Fixes #58