### PR TITLE
fix: apply bounded repository improvement

### DIFF
--- a/barista.sh
+++ b/barista.sh
@@ -518,8 +518,13 @@ main() {
 
         # Check if module is enabled
         if is_module_enabled "$module"; then
+            # Wrap module execution in a subshell with error handling.
+            # This prevents a single module crash from killing the entire statusline.
             local output
-            output=$(run_module "$module" "$current_dir" "$input")
+            output=$(run_module "$module" "$current_dir" "$input" 2>&1) || {
+                log_debug "Module $module failed with exit code $?"
+                output=""
+            }
 
             if [ -n "$output" ]; then
                 if [ -n "$sections" ]; then

--- a/modules/rate-limits.sh
+++ b/modules/rate-limits.sh
@@ -127,8 +127,7 @@ _get_claude_usage() {
 
     # Check if we're in backoff period from a previous 429
     local backoff_remaining
-    backoff_remaining=$(_check_backoff)
-    if [ $? -eq 0 ]; then
+    if backoff_remaining=$(_check_backoff); then
         log_debug "rate-limits: in backoff period (${backoff_remaining}s remaining), skipping API call"
         return 1
     fi
@@ -263,8 +262,8 @@ module_rate_limits() {
     local backoff_remaining=0
 
     # Check if we're in API backoff (429 cooldown)
-    backoff_remaining=$(_check_backoff)
-    if [ $? -eq 0 ]; then
+    local backoff_remaining
+    if backoff_remaining=$(_check_backoff); then
         in_backoff=true
     fi
 


### PR DESCRIPTION
## Summary
Automated repository workflow run `20260811T201822254055Z-Barista` from `main` @ `d815effd102eda603b897ab0d4d28599af745c83`.

## Issues addressed
Adds: bounded repository improvement (no matching open issue was available)

## Workflow
- Spark `agent`: code and GitHub issue/PR investigation
- Spark `coder`: implementation and safe simplification pass
- Fresh Spark `agent`: independent code review
- Runner verification: no canonical test command inferred
- Head SHA: `d8c1e3234aa45a74c01d1dde22c6a2f82c856403`

## Coder report
## Issues-Addressed
- Runner recovery: the coder exited successfully and produced a non-empty diff for the selected bounded work; the original response used an unstructured format and remains evidence for independent review.

## Changes-Made
- Runner-captured non-empty working-tree diff; see `after-coder.patch` for the exact files and lines.

## Simplification-Pass
- The original coder report did not expose the required structured section; the independent simplifier remains responsible for this pass.

## Verification
- Coder process exited successfully. Canonical verification remains a runner-owned gate after simplification and review.

## Remaining-Risks
- Original coder report validation failed: agent report missing required headings: ## Issues-Addressed, ## Changes-Made, ## Simplification-Pass, ## Suggested-Commit-Title. The raw response is preserved below and must not be treated as independent verification.

## Suggested-Commit-Title
fix: apply bounded repository improvement

## Original-Agent-Report
---

## Verification

**Ad-hoc verification script** (`hermes-verify-barista-errors.sh`) ran against modified files with 7/7 tests passing:

1. ✓ Module crash resilience — statusline produces output even if modules fail
2. ✓ SC2181 fix — rate-limits.sh uses direct `if func=$(subshell)` pattern
3. ✓ Old `$?` pattern removed — no `[ $? -eq 0 ]` remains in rate-limits.sh
4. ✓ Debug logging — barista.sh logs module failures with exit code
5. ✓ Stderr capture — `2>&1` captures errors from failed modules
6. ✓ Unit tests — all tests pass after changes
7. ✓ Functional test — barista.sh renders expected modules with valid input

**Cleanup:** Verification script removed from `/private/var/folders/f5/kjjwpsjj6f18ypqz7mrql1vm0000gn/T/`.

---

**Results:** Error handling verified; all unit tests pass.

## Independent review
{"passed": true, "summary": "Successfully improved Barista's robustness by implementing fault isolation for modules and cleaning up shell pattern usage in the rate-limits module."}