### PR TITLE
fix: harden barista config TUI and ship lib/ on install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Barista/
 ├── barista.conf        # Default configuration file
 ├── install.sh          # Interactive installer with arrow key navigation
 ├── VERSION             # Version tracking (semver)
+├── lib/
+│   └── config-tui.sh   # Runtime config TUI (`barista config`) — must ship with install
 ├── modules/
 │   ├── utils.sh        # Shared utility functions (MUST load first)
 │   ├── directory.sh    # Current directory module
@@ -50,7 +52,7 @@ Barista/
    - `$CLAUDE_CONFIG_DIR/barista.conf` (user overrides, defaults to `~/.claude/`)
    - `.barista.conf` in current project directory (per-project overrides)
 
-   Config files are sourced as bash, so Barista refuses to load any config that is group- or world-writable, and validates config-derived numerics before they reach `bc`/URL sinks.
+   Packaged `barista.conf` and the user override (`$CLAUDE_CONFIG_DIR/barista.conf`) are sourced as bash after a group/world-writable check. Per-directory `.barista.conf` is untrusted: `load_config_safe` (KEY=VALUE allowlist) never sources it. Config-derived numerics are validated before they reach `bc`/URL sinks. `barista config --project` uses the same safe parser.
 3. **Modules are loaded** from `modules/` directory (`utils.sh` first, then all others)
 4. **Modules are executed** in the order specified by `MODULE_ORDER` config
 5. **Output is concatenated** with the configured `SEPARATOR` and printed
@@ -180,9 +182,11 @@ Both respect `DISPLAY_MODE` for spacing and `STATUS_STYLE` for appearance (emoji
 
 Regression tests live in `tests/` (pure-bash assert harness, no framework). Each file runs standalone:
 ```bash
-bash tests/test_utils.sh        # utils.sh helpers
-bash tests/test_rate_limits.sh  # rate-limit parsers/backoff
-# also: test_cache, test_project, test_sandbox, test_update, test_uptime
+bash tests/test_utils.sh           # utils.sh helpers
+bash tests/test_rate_limits.sh     # rate-limit parsers/backoff
+bash tests/test_config_cli.sh      # barista config CLI (set/toggle/project)
+bash tests/test_install_update.sh  # installer update flags + runtime copy
+# also: test_cache, test_git_cache, test_project, test_sandbox, test_update, test_uptime
 ```
 
 Lint with `shellcheck` — `.shellcheckrc` disables SC2155 and SC2034 project-wide (see issue #21 for the policy).
@@ -238,3 +242,4 @@ The installer (`install.sh`) provides:
 - Multiple presets (minimal, developer, etc.)
 - Auto-update checking from GitHub
 - Backup/restore of previous statusline
+- Copies `barista.sh`, `VERSION`, `modules/`, and `lib/` (required for `barista config`)

--- a/README.md
+++ b/README.md
@@ -554,6 +554,6 @@ MIT License - See [LICENSE](LICENSE) for details.
 
 **Enjoy your fresh brew!** ☕
 
-*Barista v1.7.0 - Because your Claude Code deserves a great statusline.*
+*Barista v1.8.0 - Because your Claude Code deserves a great statusline.*
 
 </div>

--- a/barista.sh
+++ b/barista.sh
@@ -653,6 +653,11 @@ barista_cli_dispatch() {
     case "${1:-}" in
         config|--config)
             shift
+            if [ ! -f "$SCRIPT_DIR/lib/config-tui.sh" ]; then
+                echo "barista: missing lib/config-tui.sh (incomplete install)." >&2
+                echo "Homebrew: brew reinstall barista. From source: re-run ./install.sh." >&2
+                exit 1
+            fi
             # shellcheck disable=SC1091
             . "$SCRIPT_DIR/lib/config-tui.sh"
             barista_config_main "$@"

--- a/install.sh
+++ b/install.sh
@@ -1767,6 +1767,29 @@ do_uninstall() {
     print_info "Restart Claude Code to apply changes"
 }
 
+# Copy runtime files (script, VERSION, modules, lib) into an install prefix.
+# Testable without writing settings.json. Fail if lib/config-tui.sh is absent.
+copy_runtime_files() {
+    local src="${1:-$SCRIPT_DIR}"
+    local dest="$2"
+
+    [ -n "$dest" ] || return 1
+    [ -f "$src/barista.sh" ] || return 1
+    [ -d "$src/modules" ] || return 1
+    [ -d "$src/lib" ] || return 1
+
+    mkdir -p "$dest/modules" "$dest/lib" || return 1
+    cp "$src/barista.sh" "$dest/" || return 1
+    chmod +x "$dest/barista.sh"
+    if [ -f "$src/VERSION" ]; then
+        cp "$src/VERSION" "$dest/" || return 1
+    fi
+    cp "$src/modules/"*.sh "$dest/modules/" || return 1
+    cp "$src/lib/"*.sh "$dest/lib/" || return 1
+    [ -f "$dest/lib/config-tui.sh" ] || return 1
+    return 0
+}
+
 # =============================================================================
 # MAIN INSTALLATION
 # =============================================================================
@@ -1933,22 +1956,10 @@ do_install() {
         exit 1
     }
 
-    cp "$SCRIPT_DIR/barista.sh" "$BARISTA_DIR/" || {
-        print_error "Could not copy barista.sh"
+    if ! copy_runtime_files "$SCRIPT_DIR" "$BARISTA_DIR"; then
+        print_error "Could not copy Barista runtime files (need barista.sh, modules/, lib/config-tui.sh)"
         exit 1
-    }
-    chmod +x "$BARISTA_DIR/barista.sh"
-
-    # Copy VERSION file for version/update modules
-    if [ -f "$SCRIPT_DIR/VERSION" ]; then
-        cp "$SCRIPT_DIR/VERSION" "$BARISTA_DIR/"
     fi
-
-    mkdir -p "$BARISTA_DIR/modules"
-    cp "$SCRIPT_DIR/modules/"*.sh "$BARISTA_DIR/modules/" || {
-        print_error "Could not copy modules"
-        exit 1
-    }
 
     # Validate module files
     local module_count=$(ls -1 "$BARISTA_DIR/modules/"*.sh 2>/dev/null | wc -l | tr -d ' ')

--- a/lib/config-tui.sh
+++ b/lib/config-tui.sh
@@ -62,10 +62,93 @@ _cfg_module_var() {
     echo "MODULE_$(echo "$1" | tr '[:lower:]-' '[:upper:]_')"
 }
 
+# --set / assign allowlist: same prefixes as barista.sh load_config_safe.
+_cfg_is_allowed_key() {
+    local key="$1"
+    case "$key" in
+        *[!A-Za-z0-9_]*|'') return 1 ;;
+    esac
+    case "$key" in
+        MODULE_*|SEPARATOR|DISPLAY_MODE|COLOR_THEME|USE_ICONS|\
+        USE_STATUS_INDICATORS|STATUS_STYLE|STATUS_*|\
+        PROGRESS_BAR_*|DIRECTORY_*|CONTEXT_*|GIT_*|\
+        PROJECT_*|MODEL_*|COST_*|RATE_*|TIME_*|\
+        BATTERY_*|CPU_*|MEMORY_*|DISK_*|NETWORK_*|\
+        UPTIME_*|LOAD_*|TEMP_*|BRIGHTNESS_*|PROC_*|\
+        DOCKER_*|NODE_*|WEATHER_*|TIMEZONE_*|SANDBOX_*|\
+        CACHE_MAX_AGE|DEBUG_MODE|LAYOUT_MODE|\
+        TERMINAL_WIDTH|RIGHT_SIDE_RESERVE|VERSION_*|UPDATE_*)
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+# Keys this TUI always rewrites from current shell state.
+_cfg_is_tui_owned_key() {
+    local key="$1" mod_def name var
+    case "$key" in
+        SEPARATOR|DISPLAY_MODE|COLOR_THEME|USE_ICONS|USE_STATUS_INDICATORS|\
+        STATUS_STYLE|LAYOUT_MODE|NETWORK_SHOW_WAN|NETWORK_WAN_REDACT|MODULE_ORDER)
+            return 0
+            ;;
+    esac
+    for mod_def in "${_CFG_ALL_MODULES[@]}"; do
+        name=$(_cfg_mod_name "$mod_def")
+        var=$(_cfg_module_var "$name")
+        if [ "$key" = "$var" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+_cfg_module_name_from_var() {
+    local want="$1" mod_def name var
+    for mod_def in "${_CFG_ALL_MODULES[@]}"; do
+        name=$(_cfg_mod_name "$mod_def")
+        var=$(_cfg_module_var "$name")
+        if [ "$var" = "$want" ]; then
+            echo "$name"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Values that would break KEY="value" or inject when the user config is sourced.
+_cfg_value_is_safe() {
+    local val="$1"
+    case "$val" in
+        *\`*|*\$*|*\;*|*\|*|*\&*|*\>*|*\<*|*\"*|*\'*|*\\*|*\(*|*\)*)
+            return 1
+            ;;
+    esac
+    case "$val" in
+        *[[:cntrl:]]*) return 1 ;;
+    esac
+    return 0
+}
+
+_cfg_assign() {
+    local key="$1" val="$2"
+    _cfg_is_allowed_key "$key" || return 1
+    printf -v "$key" '%s' "$val"
+}
+
+_cfg_shell_quote() {
+    local s="$1"
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    s=${s//\$/\\\$}
+    s=${s//\`/\\\`}
+    printf '%s' "$s"
+}
+
 _cfg_module_enabled() {
     local name="$1" var val
     var=$(_cfg_module_var "$name")
-    eval "val=\${$var:-false}"
+    val="${!var:-false}"
     case "$val" in
         true|TRUE|1|yes|YES|on|ON) return 0 ;;
         *) return 1 ;;
@@ -75,7 +158,7 @@ _cfg_module_enabled() {
 _cfg_set_module() {
     local name="$1" state="$2" var
     var=$(_cfg_module_var "$name")
-    eval "$var=\"$state\""
+    printf -v "$var" '%s' "$state"
 }
 
 _cfg_toggle_module() {
@@ -107,9 +190,11 @@ _cfg_resolve_path() {
     esac
 }
 
-# Load defaults + existing conf into shell vars (trusted path only for global)
+# Load defaults + existing conf into shell vars.
+# Project .barista.conf is never sourced (same rule as barista.sh main).
 _cfg_load_into_shell() {
     local path="$1"
+    local scope="${2:-global}"
     # Ship defaults from packaged conf if present
     if [ -n "${SCRIPT_DIR:-}" ] && [ -f "$SCRIPT_DIR/barista.conf" ]; then
         if config_not_group_or_world_writable "$SCRIPT_DIR/barista.conf" 2>/dev/null; then
@@ -118,11 +203,12 @@ _cfg_load_into_shell() {
         fi
     fi
     if [ -f "$path" ]; then
-        if config_not_group_or_world_writable "$path" 2>/dev/null; then
+        if [ "$scope" = "project" ]; then
+            _cfg_load_safe_kv "$path"
+        elif config_not_group_or_world_writable "$path" 2>/dev/null; then
             # shellcheck disable=SC1090
             . "$path"
         else
-            # Safe line parser for project conf or loose perms
             _cfg_load_safe_kv "$path"
         fi
     fi
@@ -132,7 +218,9 @@ _cfg_load_into_shell() {
         name=$(_cfg_mod_name "$mod_def")
         def=$(_cfg_mod_default "$mod_def")
         var=$(_cfg_module_var "$name")
-        eval "[ -n \"\${$var+x}\" ] || $var=\"$def\""
+        if [ -z "${!var+x}" ]; then
+            printf -v "$var" '%s' "$def"
+        fi
     done
     COLOR_THEME="${COLOR_THEME:-default}"
     SEPARATOR="${SEPARATOR:- | }"
@@ -146,28 +234,25 @@ _cfg_load_into_shell() {
 }
 
 _cfg_load_safe_kv() {
+    # Prefer the shared parser in barista.sh (full prefix allowlist, printf -v).
+    if type load_config_safe >/dev/null 2>&1; then
+        load_config_safe "$1"
+        return $?
+    fi
+
     local config_path="$1" line key val
     while IFS= read -r line || [ -n "$line" ]; do
         case "$line" in
             ''|\#*) continue ;;
         esac
-        case "$line" in
-            MODULE_*=*|SEPARATOR=*|DISPLAY_MODE=*|COLOR_THEME=*|USE_ICONS=*|\
-            USE_STATUS_INDICATORS=*|STATUS_STYLE=*|LAYOUT_MODE=*|\
-            NETWORK_SHOW_WAN=*|NETWORK_WAN_REDACT=*)
-                key="${line%%=*}"
-                val="${line#*=}"
-                val="${val#\"}"; val="${val%\"}"
-                val="${val#\'}"; val="${val%\'}"
-                case "$key" in
-                    *[!A-Za-z0-9_]*|'') continue ;;
-                esac
-                case "$val" in
-                    *\$*|\`*|*\(*|*\)*|*\;*|*\|*|*\<*|*\>*) continue ;;
-                esac
-                eval "$key=\"\$val\""
-                ;;
-        esac
+        key="${line%%=*}"
+        [ "$key" = "$line" ] && continue
+        _cfg_is_allowed_key "$key" || continue
+        val="${line#*=}"
+        val="${val#\"}"; val="${val%\"}"
+        val="${val#\'}"; val="${val%\'}"
+        _cfg_value_is_safe "$val" || continue
+        printf -v "$key" '%s' "$val"
     done < "$config_path"
 }
 
@@ -186,14 +271,83 @@ _cfg_rebuild_module_order() {
     MODULE_ORDER="$order"
 }
 
+_cfg_order_add() {
+    local name="$1"
+    case ",${MODULE_ORDER}," in
+        *",${name},"*) return 0 ;;
+    esac
+    if [ -n "${MODULE_ORDER:-}" ]; then
+        MODULE_ORDER="${MODULE_ORDER},${name}"
+    else
+        MODULE_ORDER="$name"
+    fi
+}
+
+_cfg_order_remove() {
+    local name="$1" new="" m old_ifs
+    old_ifs="$IFS"
+    IFS=','
+    for m in ${MODULE_ORDER:-}; do
+        m="${m#"${m%%[![:space:]]*}"}"
+        m="${m%"${m##*[![:space:]]}"}"
+        [ -z "$m" ] && continue
+        [ "$m" = "$name" ] && continue
+        if [ -n "$new" ]; then
+            new="${new},${m}"
+        else
+            new="$m"
+        fi
+    done
+    IFS="$old_ifs"
+    MODULE_ORDER="$new"
+}
+
+_cfg_sync_module_order() {
+    local name="$1"
+    if _cfg_module_enabled "$name"; then
+        _cfg_order_add "$name"
+    else
+        _cfg_order_remove "$name"
+    fi
+}
+
+# $1 path  $2 rebuild_order (1=catalog rebuild, default 0)  $3 extra key to emit
 _cfg_write_conf() {
     local path="$1"
-    local dir
+    local rebuild_order="${2:-0}"
+    local extra_key="${3:-}"
+    local dir tmp extras line key
     dir=$(dirname "$path")
     mkdir -p "$dir" || return 1
-    _cfg_rebuild_module_order
 
-    local tmp
+    if [ "$rebuild_order" = "1" ] || [ -z "${MODULE_ORDER:-}" ]; then
+        _cfg_rebuild_module_order
+    fi
+
+    extras=""
+    if [ -f "$path" ]; then
+        while IFS= read -r line || [ -n "$line" ]; do
+            case "$line" in
+                ''|\#*) continue ;;
+            esac
+            case "$line" in
+                *=*)
+                    key="${line%%=*}"
+                    case "$key" in
+                        *[!A-Za-z0-9_]*|'') continue ;;
+                    esac
+                    if _cfg_is_tui_owned_key "$key"; then
+                        continue
+                    fi
+                    if [ -n "$extra_key" ] && [ "$key" = "$extra_key" ]; then
+                        continue
+                    fi
+                    extras="${extras}${line}"$'\n'
+                    ;;
+            esac
+        done < "$path"
+    fi
+
     tmp=$(mktemp "${TMPDIR:-/tmp}/barista-conf.XXXXXX") || return 1
 
     {
@@ -201,28 +355,37 @@ _cfg_write_conf() {
         echo "# Edit with: barista config   or hand-edit this file"
         echo ""
         echo "# Display"
-        echo "SEPARATOR=\"${SEPARATOR}\""
-        echo "DISPLAY_MODE=\"${DISPLAY_MODE}\""
-        echo "COLOR_THEME=\"${COLOR_THEME}\""
-        echo "USE_ICONS=\"${USE_ICONS}\""
-        echo "USE_STATUS_INDICATORS=\"${USE_STATUS_INDICATORS}\""
-        echo "STATUS_STYLE=\"${STATUS_STYLE}\""
-        echo "LAYOUT_MODE=\"${LAYOUT_MODE}\""
+        echo "SEPARATOR=\"$(_cfg_shell_quote "${SEPARATOR}")\""
+        echo "DISPLAY_MODE=\"$(_cfg_shell_quote "${DISPLAY_MODE}")\""
+        echo "COLOR_THEME=\"$(_cfg_shell_quote "${COLOR_THEME}")\""
+        echo "USE_ICONS=\"$(_cfg_shell_quote "${USE_ICONS}")\""
+        echo "USE_STATUS_INDICATORS=\"$(_cfg_shell_quote "${USE_STATUS_INDICATORS}")\""
+        echo "STATUS_STYLE=\"$(_cfg_shell_quote "${STATUS_STYLE}")\""
+        echo "LAYOUT_MODE=\"$(_cfg_shell_quote "${LAYOUT_MODE}")\""
         echo ""
         echo "# Network privacy"
-        echo "NETWORK_SHOW_WAN=\"${NETWORK_SHOW_WAN}\""
-        echo "NETWORK_WAN_REDACT=\"${NETWORK_WAN_REDACT}\""
+        echo "NETWORK_SHOW_WAN=\"$(_cfg_shell_quote "${NETWORK_SHOW_WAN}")\""
+        echo "NETWORK_WAN_REDACT=\"$(_cfg_shell_quote "${NETWORK_WAN_REDACT}")\""
         echo ""
         echo "# Modules"
         local mod_def name var val
         for mod_def in "${_CFG_ALL_MODULES[@]}"; do
             name=$(_cfg_mod_name "$mod_def")
             var=$(_cfg_module_var "$name")
-            eval "val=\${$var:-false}"
-            echo "${var}=\"${val}\""
+            val="${!var:-false}"
+            echo "${var}=\"$(_cfg_shell_quote "${val}")\""
         done
         echo ""
-        echo "MODULE_ORDER=\"${MODULE_ORDER}\""
+        echo "MODULE_ORDER=\"$(_cfg_shell_quote "${MODULE_ORDER}")\""
+        if [ -n "$extra_key" ] && ! _cfg_is_tui_owned_key "$extra_key"; then
+            echo ""
+            echo "${extra_key}=\"$(_cfg_shell_quote "${!extra_key}")\""
+        fi
+        if [ -n "$extras" ]; then
+            echo ""
+            echo "# Preserved settings"
+            printf '%s' "$extras"
+        fi
     } > "$tmp" || { rm -f "$tmp"; return 1; }
 
     mv "$tmp" "$path" || { rm -f "$tmp"; return 1; }
@@ -442,19 +605,19 @@ _cfg_run_interactive() {
 
     _cfg_interactive_modules "Core modules" "${_CFG_CORE_MODULES[@]}"
     [ "${_CFG_QUIT_REQUESTED:-0}" = "1" ] && { echo "Cancelled — no changes written."; return 1; }
-    [ "${_CFG_SAVE_REQUESTED:-0}" = "1" ] && { _cfg_write_conf "$path" && echo "Saved $path"; return 0; }
+    [ "${_CFG_SAVE_REQUESTED:-0}" = "1" ] && { _cfg_write_conf "$path" 1 && echo "Saved $path"; return 0; }
 
     _cfg_interactive_modules "System modules" "${_CFG_SYSTEM_MODULES[@]}"
     [ "${_CFG_QUIT_REQUESTED:-0}" = "1" ] && { echo "Cancelled — no changes written."; return 1; }
-    [ "${_CFG_SAVE_REQUESTED:-0}" = "1" ] && { _cfg_write_conf "$path" && echo "Saved $path"; return 0; }
+    [ "${_CFG_SAVE_REQUESTED:-0}" = "1" ] && { _cfg_write_conf "$path" 1 && echo "Saved $path"; return 0; }
 
     _cfg_interactive_modules "Dev modules" "${_CFG_DEV_MODULES[@]}"
     [ "${_CFG_QUIT_REQUESTED:-0}" = "1" ] && { echo "Cancelled — no changes written."; return 1; }
-    [ "${_CFG_SAVE_REQUESTED:-0}" = "1" ] && { _cfg_write_conf "$path" && echo "Saved $path"; return 0; }
+    [ "${_CFG_SAVE_REQUESTED:-0}" = "1" ] && { _cfg_write_conf "$path" 1 && echo "Saved $path"; return 0; }
 
     _cfg_interactive_modules "Extra modules" "${_CFG_EXTRA_MODULES[@]}"
     [ "${_CFG_QUIT_REQUESTED:-0}" = "1" ] && { echo "Cancelled — no changes written."; return 1; }
-    [ "${_CFG_SAVE_REQUESTED:-0}" = "1" ] && { _cfg_write_conf "$path" && echo "Saved $path"; return 0; }
+    [ "${_CFG_SAVE_REQUESTED:-0}" = "1" ] && { _cfg_write_conf "$path" 1 && echo "Saved $path"; return 0; }
 
     _cfg_interactive_choice "Color theme" \
         "default|Standard emoji" \
@@ -492,7 +655,7 @@ _cfg_run_interactive() {
             return 1
             ;;
     esac
-    if _cfg_write_conf "$path"; then
+    if _cfg_write_conf "$path" 1; then
         echo "Saved $path"
         echo "Restart Claude Code (or re-render statusline) to apply."
         return 0
@@ -571,7 +734,7 @@ barista_config_main() {
     fi
 
     # config_not_group_or_world_writable comes from barista.sh
-    _cfg_load_into_shell "$path"
+    _cfg_load_into_shell "$path" "$scope"
 
     case "$action" in
         show)
@@ -584,20 +747,23 @@ barista_config_main() {
                 echo "config: --set requires KEY=VALUE" >&2
                 return 2
             fi
-            case "$key" in
-                *[!A-Za-z0-9_]*|'')
-                    echo "config: invalid key: $key" >&2
-                    return 2
-                    ;;
-            esac
-            case "$val" in
-                *\$*|\`*|*\(*|*\)*|*\;*|*\|*)
-                    echo "config: invalid value characters" >&2
-                    return 2
-                    ;;
-            esac
-            eval "$key=\"\$val\""
-            if _cfg_write_conf "$path"; then
+            if ! _cfg_is_allowed_key "$key"; then
+                echo "config: unknown or invalid key: $key" >&2
+                return 2
+            fi
+            if ! _cfg_value_is_safe "$val"; then
+                echo "config: invalid value characters" >&2
+                return 2
+            fi
+            if ! _cfg_assign "$key" "$val"; then
+                echo "config: could not set $key" >&2
+                return 2
+            fi
+            local set_mod
+            if set_mod=$(_cfg_module_name_from_var "$key"); then
+                _cfg_sync_module_order "$set_mod"
+            fi
+            if _cfg_write_conf "$path" 0 "$key"; then
                 echo "Set $key=$val → $path"
                 return 0
             fi
@@ -610,6 +776,7 @@ barista_config_main() {
                 if [ "$name" = "$toggle_name" ]; then
                     found=1
                     _cfg_toggle_module "$name"
+                    _cfg_sync_module_order "$name"
                     break
                 fi
             done
@@ -617,7 +784,7 @@ barista_config_main() {
                 echo "config: unknown module: $toggle_name" >&2
                 return 2
             fi
-            if _cfg_write_conf "$path"; then
+            if _cfg_write_conf "$path" 0; then
                 if _cfg_module_enabled "$toggle_name"; then
                     echo "Enabled $toggle_name → $path"
                 else

--- a/tests/test_config_cli.sh
+++ b/tests/test_config_cli.sh
@@ -93,6 +93,58 @@ rc=0
 "$BARISTA" config --toggle not-a-module >/dev/null 2>&1 || rc=$?
 assert_eq "unknown module fails" "2" "$rc"
 
+# --set must not accept process-critical names or injectable values
+rc=0
+"$BARISTA" config --set PATH=/tmp/evil >/dev/null 2>&1 || rc=$?
+assert_eq "set rejects PATH" "2" "$rc"
+
+rc=0
+"$BARISTA" config --set COLOR_THEME='default" && echo PWNED #' >/dev/null 2>&1 || rc=$?
+assert_eq "set rejects quote/amp value" "2" "$rc"
+if grep -q 'PWNED' "$CLAUDE_CONFIG_DIR/barista.conf" 2>/dev/null; then
+    echo "  FAIL: injected payload written to config"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: injected payload not written"
+    PASS=$((PASS + 1))
+fi
+
+# Preserve unmanaged keys + custom MODULE_ORDER on --set
+printf '%s\n' \
+    'RATE_SHOW_PROGRESS_BAR="true"' \
+    'MODULE_GIT="true"' \
+    'MODULE_DIRECTORY="true"' \
+    'MODULE_ORDER="git,directory"' \
+    > "$CLAUDE_CONFIG_DIR/barista.conf"
+"$BARISTA" config --set COLOR_THEME=minimal >/dev/null 2>&1
+assert_file_contains "set preserves RATE_*" 'RATE_SHOW_PROGRESS_BAR="true"' "$CLAUDE_CONFIG_DIR/barista.conf"
+assert_file_contains "set preserves custom MODULE_ORDER" 'MODULE_ORDER="git,directory"' "$CLAUDE_CONFIG_DIR/barista.conf"
+assert_file_contains "set still writes theme" 'COLOR_THEME="minimal"' "$CLAUDE_CONFIG_DIR/barista.conf"
+
+# --toggle appends/removes one name; does not rebuild catalog order
+"$BARISTA" config --toggle weather >/dev/null 2>&1
+assert_file_contains "toggle appends module to order" 'MODULE_ORDER="git,directory,weather"' "$CLAUDE_CONFIG_DIR/barista.conf"
+assert_file_contains "toggle still preserves RATE_*" 'RATE_SHOW_PROGRESS_BAR="true"' "$CLAUDE_CONFIG_DIR/barista.conf"
+
+# Project .barista.conf must not be sourced (644 is typical for a cloned repo)
+PROJ_PWN="$PROJ"
+printf '%s\n' 'touch "$CLAUDE_CONFIG_DIR/pwned"' 'MODULE_CPU="true"' > "$PROJ_PWN/.barista.conf"
+chmod 644 "$PROJ_PWN/.barista.conf"
+(
+  cd "$PROJ_PWN" || exit 1
+  "$BARISTA" config --project --show >/dev/null 2>&1
+)
+if [ -e "$CLAUDE_CONFIG_DIR/pwned" ]; then
+    echo "  FAIL: project .barista.conf was sourced (pwned marker exists)"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: project .barista.conf is not sourced"
+    PASS=$((PASS + 1))
+fi
+# Safe parser should still honor KEY=VALUE
+show_proj=$(cd "$PROJ_PWN" && "$BARISTA" config --project --show 2>&1)
+assert_contains "project --show still works" "Modules:" "$show_proj"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/test_install_update.sh
+++ b/tests/test_install_update.sh
@@ -3,7 +3,8 @@
 # ABOUTME: version_lt, and Homebrew-prefix refusal. Grep counts are not enough.
 # ABOUTME: Run with: bash tests/test_install_update.sh
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$REPO_ROOT"
 INSTALL="$SCRIPT_DIR/install.sh"
 PASS=0
 FAIL=0
@@ -76,7 +77,7 @@ assert_rc "do_update refuses Homebrew prefix" 1 do_update --update --no-emoji
 assert_eq "do_update brew path does not re-exec" "" "$REEXEC_LOG"
 
 # --- do_update git path forwards original argv through _reexec_installer ---
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$REPO_ROOT"
 FAKE_ROOT=$(mktemp -d)
 mkdir -p "$FAKE_ROOT/.git"
 SCRIPT_DIR="$FAKE_ROOT"
@@ -101,6 +102,27 @@ assert_eq "bare do_update re-exec has empty argv" "" "$REEXEC_ARGS"
 rm -f "$FAKE_ROOT/.git" 2>/dev/null
 rmdir "$FAKE_ROOT/.git" 2>/dev/null
 rmdir "$FAKE_ROOT" 2>/dev/null
+
+# --- copy_runtime_files ships lib/config-tui.sh (from-source install) ---
+# do_update cds into FAKE_ROOT; use the repo root captured at the top.
+COPY_DEST=$(mktemp -d)
+assert_rc "copy_runtime_files succeeds" 0 copy_runtime_files "$REPO_ROOT" "$COPY_DEST"
+if [ -f "$COPY_DEST/lib/config-tui.sh" ]; then
+    echo "  PASS: copy_runtime_files installs config-tui.sh"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL: copy_runtime_files missing lib/config-tui.sh"
+    FAIL=$((FAIL + 1))
+fi
+if [ -x "$COPY_DEST/barista.sh" ]; then
+    echo "  PASS: copy_runtime_files installs barista.sh"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL: copy_runtime_files missing barista.sh"
+    FAIL=$((FAIL + 1))
+fi
+rm -f "$COPY_DEST/barista.sh" "$COPY_DEST/VERSION" "$COPY_DEST/lib/"*.sh "$COPY_DEST/modules/"*.sh
+rmdir "$COPY_DEST/lib" "$COPY_DEST/modules" "$COPY_DEST" 2>/dev/null
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Fixes #72
Fixes #73
Fixes #74
Fixes #75

## Why

`barista config` is the post-install surface added in v1.8.0. It had three real holes:

1. **Project configs were sourced as bash** when mode was 644 (normal clone). Statusline rendering already uses `load_config_safe` and never sources `.barista.conf`.
2. **`--set` accepted any identifier** (`PATH`, …) and wrote unescaped values (`"` / `&`) into `$CLAUDE_CONFIG_DIR/barista.conf`, which `load_config` later sources.
3. **Every save rewrote the whole file** (dropped `RATE_*`, custom `MODULE_ORDER`) and **from-source `install.sh` omitted `lib/`**, so `barista.sh config` failed after `./install.sh`. Homebrew already installs `lib`.

## What changed

- Never source project `.barista.conf`; reuse `load_config_safe`.
- Allowlist `--set` keys (same prefixes as the safe parser); assign with `printf -v`; reject injectable values.
- Merge-write: keep unmanaged keys; only rebuild `MODULE_ORDER` in the interactive TUI; `--toggle` / `--set MODULE_*` add/remove one name.
- `install.sh copy_runtime_files` copies `lib/*.sh` and fails if `config-tui.sh` is missing.
- Clear error if `lib/config-tui.sh` is absent at runtime.
- README footer 1.8.0; CLAUDE.md documents `lib/` and the trusted-source vs safe-parser split.

## Tests

```
bash tests/test_utils.sh
bash tests/test_rate_limits.sh
bash tests/test_config_cli.sh
bash tests/test_install_update.sh
bash tests/test_cache.sh
bash tests/test_git_cache.sh
bash tests/test_project.sh
bash tests/test_sandbox.sh
bash tests/test_update.sh
bash tests/test_uptime.sh
```

All 10 files passed (225 assertions). New coverage: `--set` rejects `PATH` and quote/amp payloads, project `.barista.conf` is not sourced, extra keys / custom `MODULE_ORDER` survive `--set`/`--toggle`, `copy_runtime_files` installs `lib/config-tui.sh`.