### PR TITLE
Drop unsafe extras when rewriting project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ No other configuration changes are needed.
 
 #### Per-Directory Overrides
 
-Create `.barista.conf` in any project directory to customize the statusline for that project:
+Create `.barista.conf` in any project directory to customize the statusline for that project. That file is **never sourced** — only allowlisted `KEY=VALUE` lines are applied (`load_config_safe`).
 
 ```bash
 # ~/myproject/.barista.conf
@@ -344,9 +344,9 @@ MODULE_ORDER="directory,context,git,model"
 
 Configuration is loaded in order of precedence:
 1. Built-in defaults
-2. `barista.conf` (in script directory)
-3. `$CLAUDE_CONFIG_DIR/barista.conf` (user overrides, defaults to `~/.claude/`)
-4. `.barista.conf` (per-directory overrides)
+2. `barista.conf` (in script directory — sourced as bash after a writable check)
+3. `$CLAUDE_CONFIG_DIR/barista.conf` (user overrides, defaults to `~/.claude/` — also sourced)
+4. `.barista.conf` (per-directory KEY=VALUE allowlist; never sourced)
 
 ### Full Configuration Options
 
@@ -506,8 +506,9 @@ MODULE_ORDER="...,mycustom,..."
 - Try a different terminal emulator if issues persist
 
 ### Config file not loading
-- Barista refuses to source a `barista.conf` or `.barista.conf` that is group- or world-writable (it's executed as bash, so a writable config is a code-execution vector)
-- Fix with `chmod 644 barista.conf`
+- Packaged `barista.conf` and `$CLAUDE_CONFIG_DIR/barista.conf` are sourced as bash. Barista refuses to source either if they are group- or world-writable.
+- Fix the **user** file with `chmod 600 "$CLAUDE_CONFIG_DIR/barista.conf"` (or `644` if you want it world-readable but not writable).
+- Per-directory `.barista.conf` is never sourced. `chmod` on that file does not make it executable.
 
 ### Testing manually
 ```bash

--- a/barista.sh
+++ b/barista.sh
@@ -168,9 +168,10 @@ load_config_safe() {
                     \'*\') val="${val#\'}"; val="${val%\'}" ;;
                 esac
 
-                # Reject values containing shell metacharacters
+                # Reject shell metacharacters. Allow `|` so SEPARATOR=" | " loads.
+                # Reject `$` and glob chars so project files cannot park them.
                 case "$val" in
-                    *\`*|*\$\(*|*\;*|*\|*|*\&*|*\>*|*\<*) continue ;;
+                    *\`*|*\$*|*\;*|*\&*|*\>*|*\<*|*'*'*|*'?'*|*'['*) continue ;;
                 esac
 
                 # Safe to assign via printf into the variable

--- a/lib/config-tui.sh
+++ b/lib/config-tui.sh
@@ -117,10 +117,12 @@ _cfg_module_name_from_var() {
 }
 
 # Values that would break KEY="value" or inject when the user config is sourced.
+# Allow `|` so SEPARATOR=" | " (the shipped default) can be --set.
+# Reject glob chars so MODULE_ORDER=* cannot expand cwd names on toggle.
 _cfg_value_is_safe() {
     local val="$1"
     case "$val" in
-        *\`*|*\$*|*\;*|*\|*|*\&*|*\>*|*\<*|*\"*|*\'*|*\\*|*\(*|*\)*)
+        *\`*|*\$*|*\;*|*\&*|*\>*|*\<*|*\"*|*\'*|*\\*|*\(*|*\)*|*'*'*|*'?'*|*'['*)
             return 1
             ;;
     esac
@@ -133,6 +135,7 @@ _cfg_value_is_safe() {
 _cfg_assign() {
     local key="$1" val="$2"
     _cfg_is_allowed_key "$key" || return 1
+    _cfg_value_is_safe "$val" || return 1
     printf -v "$key" '%s' "$val"
 }
 
@@ -286,6 +289,7 @@ _cfg_order_add() {
 _cfg_order_remove() {
     local name="$1" new="" m old_ifs
     old_ifs="$IFS"
+    set -f
     IFS=','
     for m in ${MODULE_ORDER:-}; do
         m="${m#"${m%%[![:space:]]*}"}"
@@ -299,6 +303,7 @@ _cfg_order_remove() {
         fi
     done
     IFS="$old_ifs"
+    set +f
     MODULE_ORDER="$new"
 }
 
@@ -316,7 +321,7 @@ _cfg_write_conf() {
     local path="$1"
     local rebuild_order="${2:-0}"
     local extra_key="${3:-}"
-    local dir tmp extras line key
+    local dir tmp extras line key extra_val
     dir=$(dirname "$path")
     mkdir -p "$dir" || return 1
 
@@ -333,16 +338,25 @@ _cfg_write_conf() {
             case "$line" in
                 *=*)
                     key="${line%%=*}"
+                    extra_val="${line#*=}"
                     case "$key" in
                         *[!A-Za-z0-9_]*|'') continue ;;
                     esac
+                    if ! _cfg_is_allowed_key "$key"; then
+                        continue
+                    fi
                     if _cfg_is_tui_owned_key "$key"; then
                         continue
                     fi
                     if [ -n "$extra_key" ] && [ "$key" = "$extra_key" ]; then
                         continue
                     fi
-                    extras="${extras}${line}"$'\n'
+                    case "$extra_val" in
+                        \"*\") extra_val="${extra_val#\"}"; extra_val="${extra_val%\"}" ;;
+                        \'*\') extra_val="${extra_val#\'}"; extra_val="${extra_val%\'}" ;;
+                    esac
+                    _cfg_value_is_safe "$extra_val" || continue
+                    extras="${extras}${key}=\"$(_cfg_shell_quote "$extra_val")\""$'\n'
                     ;;
             esac
         done < "$path"
@@ -377,7 +391,8 @@ _cfg_write_conf() {
         done
         echo ""
         echo "MODULE_ORDER=\"$(_cfg_shell_quote "${MODULE_ORDER}")\""
-        if [ -n "$extra_key" ] && ! _cfg_is_tui_owned_key "$extra_key"; then
+        if [ -n "$extra_key" ] && ! _cfg_is_tui_owned_key "$extra_key" \
+            && _cfg_is_allowed_key "$extra_key" && _cfg_value_is_safe "${!extra_key}"; then
             echo ""
             echo "${extra_key}=\"$(_cfg_shell_quote "${!extra_key}")\""
         fi

--- a/tests/test_config_cli.sh
+++ b/tests/test_config_cli.sh
@@ -144,6 +144,64 @@ fi
 # Safe parser should still honor KEY=VALUE
 show_proj=$(cd "$PROJ_PWN" && "$BARISTA" config --project --show 2>&1)
 assert_contains "project --show still works" "Modules:" "$show_proj"
+assert_contains "project --show honors MODULE_CPU" "[on ] cpu" "$show_proj"
+
+# --project --set must not copy extras that are not allowlisted / not safe
+printf '%s\n' \
+    'touch "$CLAUDE_CONFIG_DIR/pwned2"' \
+    'PATH=/tmp/evil' \
+    'IFS=hack' \
+    'BASH_ENV=/tmp/evil.bashrc' \
+    'RATE_SHOW_PROGRESS_BAR="true"; echo PWNED_EXTRA' \
+    'MODULE_CPU="true"' \
+    > "$PROJ_PWN/.barista.conf"
+chmod 644 "$PROJ_PWN/.barista.conf"
+(
+  cd "$PROJ_PWN" || exit 1
+  "$BARISTA" config --project --set COLOR_THEME=minimal >/dev/null 2>&1
+)
+if [ -e "$CLAUDE_CONFIG_DIR/pwned2" ]; then
+    echo "  FAIL: project --set sourced .barista.conf"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: project --set does not source .barista.conf"
+    PASS=$((PASS + 1))
+fi
+assert_file_contains "project --set writes theme" 'COLOR_THEME="minimal"' "$PROJ_PWN/.barista.conf"
+if grep -qE 'PATH=|IFS=|BASH_ENV=|PWNED_EXTRA|touch ' "$PROJ_PWN/.barista.conf"; then
+    echo "  FAIL: project --set copied unsafe extras"
+    FAIL=$((FAIL + 1))
+    echo "    file:"
+    cat "$PROJ_PWN/.barista.conf"
+else
+    echo "  PASS: project --set drops PATH/IFS/BASH_ENV/injection extras"
+    PASS=$((PASS + 1))
+fi
+
+# Documented default separator must be settable
+rc=0
+"$BARISTA" config --set 'SEPARATOR= | ' >/dev/null 2>&1 || rc=$?
+assert_eq "set allows pipe separator" "0" "$rc"
+assert_file_contains "set writes pipe separator" 'SEPARATOR=" | "' "$CLAUDE_CONFIG_DIR/barista.conf"
+
+# MODULE_ORDER=* must not expand cwd names
+rc=0
+"$BARISTA" config --set 'MODULE_ORDER=*' >/dev/null 2>&1 || rc=$?
+assert_eq "set rejects MODULE_ORDER glob" "2" "$rc"
+touch "$TMPHOME/STAR_GLOB_MARKER"
+printf '%s\n' 'MODULE_ORDER="*"' 'MODULE_GIT="true"' > "$CLAUDE_CONFIG_DIR/barista.conf"
+(
+  cd "$TMPHOME" || exit 1
+  "$BARISTA" config --toggle git >/dev/null 2>&1
+)
+if grep -q 'STAR_GLOB_MARKER' "$CLAUDE_CONFIG_DIR/barista.conf"; then
+    echo "  FAIL: toggle expanded MODULE_ORDER glob into filenames"
+    FAIL=$((FAIL + 1))
+    cat "$CLAUDE_CONFIG_DIR/barista.conf"
+else
+    echo "  PASS: toggle does not expand MODULE_ORDER globs"
+    PASS=$((PASS + 1))
+fi
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Follow-up after #76. Config TUI rewrite only persists allowlisted extras. Do not merge until reviewed.